### PR TITLE
[UPDATE] #90 AI 프롬프트 DB 조회 연동

### DIFF
--- a/src/main/java/com/sashimi/ai/infrastructure/persistence/AiPromptJpaEntity.java
+++ b/src/main/java/com/sashimi/ai/infrastructure/persistence/AiPromptJpaEntity.java
@@ -1,0 +1,44 @@
+package com.sashimi.ai.infrastructure.persistence;
+
+import com.sashimi.ai.domain.model.AiPrompt;
+import com.sashimi.ai.domain.model.AiPromptType;
+import jakarta.persistence.*;
+
+@Entity
+@Table(name = "ai_prompts")
+public class AiPromptJpaEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "prompt_id")
+    private Long promptId;
+
+    @Column(nullable = false)
+    private String name;
+
+    @Column(nullable = false)
+    private String purpose;
+
+    @Column(nullable = false, columnDefinition = "TEXT")
+    private String prompt;
+
+    @Column(nullable = false)
+    private int version;
+
+    @Column(name = "is_active", nullable = false)
+    private boolean active;
+
+    protected AiPromptJpaEntity() {
+    }
+
+    public AiPrompt toDomain(AiPromptType promptType) {
+        return new AiPrompt(
+                promptId,
+                name,
+                promptType,
+                prompt,
+                version,
+                active
+        );
+    }
+}

--- a/src/main/java/com/sashimi/ai/infrastructure/persistence/AiPromptRepositoryAdapter.java
+++ b/src/main/java/com/sashimi/ai/infrastructure/persistence/AiPromptRepositoryAdapter.java
@@ -1,0 +1,37 @@
+package com.sashimi.ai.infrastructure.persistence;
+
+import com.sashimi.ai.domain.model.AiPrompt;
+import com.sashimi.ai.domain.model.AiPromptType;
+import com.sashimi.ai.domain.repository.AiPromptRepository;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+@Profile("gemini")
+public class AiPromptRepositoryAdapter implements AiPromptRepository {
+
+    private final SpringDataAiPromptRepository repository;
+
+    public AiPromptRepositoryAdapter(SpringDataAiPromptRepository repository) {
+        this.repository = repository;
+    }
+
+    @Override
+    public Optional<AiPrompt> findActiveByType(AiPromptType promptType) {
+        String purpose = toPurpose(promptType);
+
+        return repository.findFirstByPurposeAndActiveTrueOrderByVersionDesc(purpose)
+                .map(entity -> entity.toDomain(promptType));
+    }
+
+    private String toPurpose(AiPromptType promptType) {
+        return switch (promptType) {
+            case RESUME_GENERATE -> "RESUME_GENERATION";
+            case RESUME_REVIEW -> "RESUME_EVALUATION";
+            case JOB_POSTING_ANALYSIS -> "JOB_ANALYSIS";
+            default -> throw new IllegalArgumentException("지원하지 않는 AI 프롬프트 타입입니다.");
+        };
+    }
+}

--- a/src/main/java/com/sashimi/ai/infrastructure/persistence/InMemoryAiPromptRepositoryAdapter.java
+++ b/src/main/java/com/sashimi/ai/infrastructure/persistence/InMemoryAiPromptRepositoryAdapter.java
@@ -4,6 +4,7 @@ import com.sashimi.ai.domain.model.AiPrompt;
 import com.sashimi.ai.domain.model.AiPromptType;
 import com.sashimi.ai.domain.repository.AiPromptRepository;
 import org.springframework.stereotype.Repository;
+import org.springframework.context.annotation.Profile;
 
 import java.util.Optional;
 
@@ -11,6 +12,7 @@ import java.util.Optional;
  * 개발 초기 단계에서 사용하는 임시 AI 프롬프트 저장소 Adapter.
  */
 @Repository
+@Profile("local")
 public class InMemoryAiPromptRepositoryAdapter implements AiPromptRepository {
 
     private final AiPrompt resumeReviewPrompt = new AiPrompt(

--- a/src/main/java/com/sashimi/ai/infrastructure/persistence/SpringDataAiPromptRepository.java
+++ b/src/main/java/com/sashimi/ai/infrastructure/persistence/SpringDataAiPromptRepository.java
@@ -1,0 +1,10 @@
+package com.sashimi.ai.infrastructure.persistence;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface SpringDataAiPromptRepository extends JpaRepository<AiPromptJpaEntity, Long> {
+
+    Optional<AiPromptJpaEntity> findFirstByPurposeAndActiveTrueOrderByVersionDesc(String purpose);
+}

--- a/src/main/java/com/sashimi/ai/infrastructure/prompt/JobPostingRecommendationPromptBuilder.java
+++ b/src/main/java/com/sashimi/ai/infrastructure/prompt/JobPostingRecommendationPromptBuilder.java
@@ -1,81 +1,81 @@
 package com.sashimi.ai.infrastructure.prompt;
 
+import com.sashimi.ai.domain.model.AiPrompt;
 import com.sashimi.recommendation.domain.model.JobPostingRecommendation;
 import org.springframework.stereotype.Component;
 
 @Component
 public class JobPostingRecommendationPromptBuilder {
 
-    public String build(JobPostingRecommendation recommendation) {
+    public String build(JobPostingRecommendation recommendation, AiPrompt prompt) {
         String jobPostingInput = switch (recommendation.inputType()) {
-            case URL -> """
-                    The user submitted a job posting URL.
-                    URL: %s
-
-                    URL crawling is not implemented yet.
-                    Infer a reasonable analysis only from the URL and general job posting context.
-                    """.formatted(recommendation.sourceUrl());
-
-            case TEXT -> """
-                    The user submitted this job posting text:
-
-                    %s
-                    """.formatted(recommendation.rawContent());
+            case URL -> "URL: " + recommendation.sourceUrl();
+            case TEXT -> recommendation.rawContent();
         };
 
+        String userPrompt = prompt.prompt()
+                .replace("{resumeBased}", String.valueOf(recommendation.resumeBased()))
+                .replace("{jobPostingContent}", safe(jobPostingInput));
+
         return """
-                You are an AI assistant for an LMS career recommendation feature.
+            You are an AI assistant for an LMS career recommendation feature.
 
-                Analyze the job posting and return ONLY valid JSON.
-                Do not include markdown fences.
-                Do not include explanation outside JSON.
+            Analyze the job posting and return ONLY valid JSON.
+            Do not include markdown fences.
+            Do not include explanation outside JSON.
 
-                Rules:
-                - Extract required skills from the job posting.
-                - Recommend certificates related to the job role and required skills.
-                - Recommend courses that can help the user fill missing skills.
-                - If resumeBased is false, set matchRate to null and requiredSkills[].matched to null.
-                - If resumeBased is true, estimate matchRate from 0 to 100 and set requiredSkills[].matched to true or false.
-                - Return Korean text for course titles, certificate reasons, and recommendation reasons.
+            Rules:
+            - Extract required skills from the job posting.
+            - Recommend certificates related to the job role and required skills.
+            - Recommend courses that can help the user fill missing skills.
+            - If resumeBased is false, set matchRate to null and requiredSkills[].matched to null.
+            - If resumeBased is true, estimate matchRate from 0 to 100 and set requiredSkills[].matched to true or false.
+            - Return Korean text for course titles, certificate reasons, and recommendation reasons.
 
-                resumeBased: %s
-
-                Required JSON format:
+            Required JSON format:
+            {
+              "jobTitle": "Frontend Developer",
+              "matchRate": 56,
+              "requiredSkills": [
                 {
-                  "jobTitle": "Frontend Developer",
-                  "matchRate": 56,
-                  "requiredSkills": [
-                    {
-                      "name": "React",
-                      "category": "Frontend",
-                      "matched": true
-                    }
-                  ],
-                  "courses": [
-                    {
-                      "courseId": 1,
-                      "title": "실무에서 바로 쓰는 GraphQL 완전 정복",
-                      "instructor": "김민준",
-                      "matchedSkill": "GraphQL",
-                      "reason": "공고에서 GraphQL 역량을 요구하므로 보완 학습에 적합합니다."
-                    }
-                  ],
-                  "certificates": [
-                    {
-                      "certificationId": 1,
-                      "name": "AWS Cloud Practitioner",
-                      "reason": "AWS 클라우드 기초 역량을 증명하는 데 적합합니다.",
-                      "relatedSkills": ["AWS"],
-                      "difficulty": "쉬움"
-                    }
-                  ]
+                  "name": "React",
+                  "category": "Frontend",
+                  "matched": true
                 }
+              ],
+              "courses": [
+                {
+                  "courseId": 1,
+                  "title": "실무에서 바로 쓰는 GraphQL 완전 정복",
+                  "instructor": "김민준",
+                  "matchedSkill": "GraphQL",
+                  "reason": "공고에서 GraphQL 역량을 요구하므로 보완 학습에 적합합니다."
+                }
+              ],
+              "certificates": [
+                {
+                  "certificationId": 1,
+                  "name": "AWS Cloud Practitioner",
+                  "reason": "AWS 클라우드 기초 역량을 증명하는 데 적합합니다.",
+                  "relatedSkills": ["AWS"],
+                  "difficulty": "쉬움"
+                }
+              ]
+            }
 
-                Job posting input:
-                %s
-                """.formatted(
-                recommendation.resumeBased(),
-                jobPostingInput
+            Prompt name: %s
+            Prompt version: %d
+
+            User prompt:
+            %s
+            """.formatted(
+                prompt.name(),
+                prompt.version(),
+                userPrompt
         );
+    }
+
+    private String safe(String value) {
+        return value == null ? "" : value;
     }
 }

--- a/src/main/java/com/sashimi/recommendation/application/port/JobPostingRecommendationAnalyzePort.java
+++ b/src/main/java/com/sashimi/recommendation/application/port/JobPostingRecommendationAnalyzePort.java
@@ -1,8 +1,9 @@
 package com.sashimi.recommendation.application.port;
 
+import com.sashimi.ai.domain.model.AiPrompt;
 import com.sashimi.recommendation.domain.model.JobPostingRecommendation;
 
 public interface JobPostingRecommendationAnalyzePort {
 
-    JobPostingRecommendationAnalyzeResult analyze(JobPostingRecommendation recommendation);
+    JobPostingRecommendationAnalyzeResult analyze(JobPostingRecommendation recommendation, AiPrompt prompt);
 }

--- a/src/main/java/com/sashimi/recommendation/application/service/JobPostingRecommendationService.java
+++ b/src/main/java/com/sashimi/recommendation/application/service/JobPostingRecommendationService.java
@@ -1,5 +1,8 @@
 package com.sashimi.recommendation.application.service;
 
+import com.sashimi.ai.domain.model.AiPrompt;
+import com.sashimi.ai.domain.model.AiPromptType;
+import com.sashimi.ai.domain.repository.AiPromptRepository;
 import com.sashimi.global.exception.BusinessException;
 import com.sashimi.global.exception.ErrorCode;
 import com.sashimi.recommendation.application.command.CreateJobPostingRecommendationCommand;
@@ -26,15 +29,18 @@ public class JobPostingRecommendationService implements
     private final JobPostingRecommendationRepository recommendationRepository;
     private final JobPostingRecommendationAnalyzePort analyzePort;
     private final JobPostingRecommendationPolicy recommendationPolicy;
+    private final AiPromptRepository aiPromptRepository;
 
     public JobPostingRecommendationService(
             JobPostingRecommendationRepository recommendationRepository,
             JobPostingRecommendationAnalyzePort analyzePort,
-            JobPostingRecommendationPolicy recommendationPolicy
+            JobPostingRecommendationPolicy recommendationPolicy,
+            AiPromptRepository aiPromptRepository
     ) {
         this.recommendationRepository = recommendationRepository;
         this.analyzePort = analyzePort;
         this.recommendationPolicy = recommendationPolicy;
+        this.aiPromptRepository = aiPromptRepository;
     }
 
     @Override
@@ -52,7 +58,10 @@ public class JobPostingRecommendationService implements
 
         JobPostingRecommendation savedRecommendation = recommendationRepository.save(recommendation);
 
-        JobPostingRecommendationAnalyzeResult analyzeResult = analyzePort.analyze(savedRecommendation);
+        AiPrompt prompt = aiPromptRepository.findActiveByType(AiPromptType.JOB_POSTING_ANALYSIS)
+                .orElseThrow(() -> new BusinessException(ErrorCode.AI_PROMPT_NOT_FOUND));
+
+        JobPostingRecommendationAnalyzeResult analyzeResult = analyzePort.analyze(savedRecommendation, prompt);
 
         JobPostingRecommendation analyzedRecommendation = savedRecommendation.analyzed(
                 analyzeResult.jobTitle(),

--- a/src/main/java/com/sashimi/recommendation/infrastructure/ai/GeminiJobPostingRecommendationAnalyzeAdapter.java
+++ b/src/main/java/com/sashimi/recommendation/infrastructure/ai/GeminiJobPostingRecommendationAnalyzeAdapter.java
@@ -15,6 +15,7 @@ import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Component;
 import tools.jackson.databind.JsonNode;
 import tools.jackson.databind.ObjectMapper;
+import com.sashimi.ai.domain.model.AiPrompt;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -39,8 +40,8 @@ public class GeminiJobPostingRecommendationAnalyzeAdapter
     }
 
     @Override
-    public JobPostingRecommendationAnalyzeResult analyze(JobPostingRecommendation recommendation) {
-        String prompt = promptBuilder.build(recommendation);
+    public JobPostingRecommendationAnalyzeResult analyze(JobPostingRecommendation recommendation, AiPrompt aiPrompt) {
+        String prompt = promptBuilder.build(recommendation, aiPrompt);
 
         String generatedText = geminiTextClient.generate(prompt);
 

--- a/src/main/java/com/sashimi/recommendation/infrastructure/ai/StubJobPostingRecommendationAnalyzeAdapter.java
+++ b/src/main/java/com/sashimi/recommendation/infrastructure/ai/StubJobPostingRecommendationAnalyzeAdapter.java
@@ -1,5 +1,6 @@
 package com.sashimi.recommendation.infrastructure.ai;
 
+import com.sashimi.ai.domain.model.AiPrompt;
 import com.sashimi.recommendation.application.port.JobPostingRecommendationAnalyzePort;
 import com.sashimi.recommendation.application.port.JobPostingRecommendationAnalyzeResult;
 import com.sashimi.recommendation.domain.model.CertificateRecommendation;
@@ -17,7 +18,10 @@ public class StubJobPostingRecommendationAnalyzeAdapter
         implements JobPostingRecommendationAnalyzePort {
 
     @Override
-    public JobPostingRecommendationAnalyzeResult analyze(JobPostingRecommendation recommendation) {
+    public JobPostingRecommendationAnalyzeResult analyze(
+            JobPostingRecommendation recommendation,
+            AiPrompt prompt
+    ) {
         boolean resumeBased = recommendation.resumeBased();
 
         return new JobPostingRecommendationAnalyzeResult(

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -287,10 +287,21 @@ VALUES
 INSERT INTO ai_prompts
 (name, purpose, prompt, version, is_active)
 VALUES
-    ('이력서 생성 프롬프트 v1', 'RESUME_GENERATION', '사용자의 경력과 기술스택을 바탕으로 신입 개발자 이력서를 작성한다.', 1, TRUE),
-    ('이력서 평가 프롬프트 v1', 'RESUME_EVALUATION', '채용공고와 이력서를 비교하여 강점, 약점, 개선점을 평가한다.', 1, TRUE),
-    ('채용공고 분석 프롬프트 v1', 'JOB_ANALYSIS', '채용공고에서 핵심 요구 기술과 우대사항을 추출한다.', 1, TRUE),
-    ('강의 추천 프롬프트 v1', 'COURSE_RECOMMENDATION', '사용자의 목표와 부족한 기술을 바탕으로 적합한 강의를 추천한다.', 1, TRUE);
+    ('이력서 생성 프롬프트 v1', 'RESUME_GENERATION',
+     '사용자의 경력과 기술스택을 바탕으로 신입 개발자 이력서 초안을 작성해주세요. 사용자 정보: {userProfile}',
+     1, TRUE),
+
+    ('이력서 평가 프롬프트 v1', 'RESUME_EVALUATION',
+     '아래 이력서 내용을 기반으로 강점, 약점, 개선점을 평가해주세요. 이력서 제목: {resumeTitle}, 이력서 내용: {resumeContent}',
+     1, TRUE),
+
+    ('채용공고 분석 프롬프트 v1', 'JOB_ANALYSIS',
+     '아래 채용공고 내용을 분석해서 직무명, 요구 역량, 추천 자격증, 보완 학습이 필요한 강의 방향을 도출해주세요. 이력서 보유 여부: {resumeBased}, 채용공고 내용: {jobPostingContent}',
+     1, TRUE),
+
+    ('강의 추천 프롬프트 v1', 'COURSE_RECOMMENDATION',
+     '사용자의 목표, 부족한 기술, 채용공고 요구 역량을 바탕으로 적합한 강의를 추천해주세요. 목표: {targetGoal}, 부족한 기술: {missingSkills}, 요구 역량: {requiredSkills}',
+     1, TRUE);
 
 INSERT INTO resumes
 (title, template_type, content, is_default, user_id)


### PR DESCRIPTION
## 📌 PR 요약
- 기존: InMemoryAiPromptRepositoryAdapter에서 하드코딩 프롬프트 사용
- 변경: ai_prompts 테이블에서 활성 프롬프트를 조회하여 AI Adapter에 전달

---

## 🛠️ 작업 상세 내용 (체크로 선택)
- [ ] ✨ FEATURE
- [x] 🔧 UPDATE
- [ ] 🐛 BUGFIX
- [ ] ♻️ REFACTOR
- [ ] 📝 DOCS

---

## 📋 작업 상세 내용
- AI_PROMPTS 테이블 기반 프롬프트 조회 Adapter 추가
- AiPromptJpaEntity 추가
- SpringDataAiPromptRepository 추가
- AiPromptRepositoryAdapter 추가
- InMemoryAiPromptRepositoryAdapter를 local 프로필 전용으로 분리
- 이력서 평가 프롬프트에 resumeTitle, resumeContent 치환값 반영
- 채용공고 분석 프롬프트에 resumeBased, jobPostingContent 치환값 반영
- 채용공고 추천 생성 흐름에서 JOB_ANALYSIS 프롬프트 조회 후 AI Adapter로 전달

---

## 🔗 PR 관련 이슈로 닫기
Closes #90

---

## ✅ 체크리스트 (확인 절차)
- [x] 정상적으로 빌드 및 실행됩니다.
- [x] 주요 기능이 정상 동작합니다.
- [x] 불필요한 코드를 제거했습니다.
- [ ] 코드 리뷰 준비가 완료되었습니다.

---

## 💬 리뷰어에게 할 말
- 로그인 토큰 발급 과정이 필요하여 Postman 실행 테스트는 추후 통합 테스트 단계에서 진행 예정
- 실제 Gemini 호출을 위해 GEMINI_API_KEY 환경변수 설정 필요

---