### PR TITLE
[BUGFIX] #85 자격증 OCR 합격일자 파싱 오류 해결

### DIFF
--- a/src/main/java/com/sashimi/auth/controller/request.http
+++ b/src/main/java/com/sashimi/auth/controller/request.http
@@ -27,7 +27,7 @@ Content-Type: application/json
 Accept: application/json
 
 {
-  "loginId": "student02",
+  "loginId": "student01",
   "password": "student"
 }
 ### 토큰 재발급

--- a/src/main/java/com/sashimi/member/infrastructure/OcrAdapter.java
+++ b/src/main/java/com/sashimi/member/infrastructure/OcrAdapter.java
@@ -132,8 +132,10 @@ public class OcrAdapter implements OcrPort {
     }
 
     private LocalDate extractIssueDate(String text) {
-        // "합격일자" 키워드 뒤 날짜 우선 추출
-        Pattern passPattern = Pattern.compile("합격\\s*일\\s*자\\s*(\\d{4})년\\s*(\\d{1,2})월\\s*(\\d{1,2})일");
+        // 띄어쓰기 포함한 "합격일자" 패턴
+        Pattern passPattern = Pattern.compile(
+                "합\\s*격\\s*일\\s*자\\s*(\\d{4})년\\s*(\\d{1,2})월\\s*(\\d{1,2})일"
+        );
         Matcher passMatcher = passPattern.matcher(text);
         if (passMatcher.find()) {
             return LocalDate.of(
@@ -143,7 +145,7 @@ public class OcrAdapter implements OcrPort {
             );
         }
 
-        // 없으면 첫 번째 날짜 가져오기
+        // 없으면 첫 번째 날짜
         Pattern pattern = Pattern.compile("(\\d{4})[년.\\-]\\s*(\\d{1,2})[월.\\-]\\s*(\\d{1,2})");
         Matcher matcher = pattern.matcher(text);
         if (matcher.find()) {


### PR DESCRIPTION
## 📌 PR 요약
- OCR이 자격증의 합격일자 대신 생년월일을 저장하는 버그를 수정했습니다.
---

## 🛠️ 작업 상세 내용 (체크로 선택)
- [ ] ✨ FEATURE
- [x] 🔧 UPDATE
- [ ] 🐛 BUGFIX
- [ ] ♻️ REFACTOR
- [ ] 📝 DOCS

---

## 📋 작업 상세 내용
- OCR 텍스트에서 "합 격 일 자" 띄어쓰기 패턴을 인식하도록 정규식 수정
- 합격일자 키워드 뒤 날짜를 우선 추출하도록 파싱 로직 개선

---

## 🔗 PR 관련 이슈로 닫기
Closes #85 

---

## ✅ 체크리스트 (확인 절차)
- [ ] 정상적으로 빌드 및 실행됩니다.
- [ ] 주요 기능이 정상 동작합니다.
- [ ] 불필요한 코드를 제거했습니다.
- [ ] 코드 리뷰 준비가 완료되었습니다.

---

## 💬 리뷰어에게 할 말
- 
<img width="1405" height="1065" alt="image" src="https://github.com/user-attachments/assets/afa42ec4-65f9-43e5-a67f-b21e9c256a75" />
<img width="456" height="111" alt="image" src="https://github.com/user-attachments/assets/2b8b14a3-13d9-4131-bbcd-8e20e7d0f214" />


---