### PR TITLE
[FEATURE] #95 자격증 등록 API 응답에 자격증 정보 반환 추가

### DIFF
--- a/src/main/java/com/sashimi/member/application/service/CertificateCommandService.java
+++ b/src/main/java/com/sashimi/member/application/service/CertificateCommandService.java
@@ -6,6 +6,7 @@ import com.sashimi.member.application.port.OcrPort;
 import com.sashimi.member.application.usecase.CertificateCommandUseCase;
 import com.sashimi.member.domain.model.UserCertification;
 import com.sashimi.member.domain.repository.UserCertificationRepository;
+import com.sashimi.member.presentation.api.response.CertificateResponse;
 import com.sashimi.global.exception.BusinessException;
 import com.sashimi.global.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
@@ -21,7 +22,7 @@ public class CertificateCommandService implements CertificateCommandUseCase {
     private final OcrPort ocrPort;
 
     @Override
-    public void registerCertificate(RegisterCertificateCommand command) {
+    public CertificateResponse registerCertificate(RegisterCertificateCommand command) {
 
         OcrPort.OcrResult result = ocrPort.extractCertificateInfo(command.fileBytes(), command.fileName());
 
@@ -37,7 +38,8 @@ public class CertificateCommandService implements CertificateCommandUseCase {
                 command.fileName()
         );
         certification.verify();
-        userCertificationRepository.save(certification);
+        UserCertification saved = userCertificationRepository.save(certification);
+        return CertificateResponse.from(saved);
     }
 
     @Override

--- a/src/main/java/com/sashimi/member/application/usecase/CertificateCommandUseCase.java
+++ b/src/main/java/com/sashimi/member/application/usecase/CertificateCommandUseCase.java
@@ -2,10 +2,11 @@ package com.sashimi.member.application.usecase;
 
 import com.sashimi.member.application.command.DeleteCertificateCommand;
 import com.sashimi.member.application.command.RegisterCertificateCommand;
+import com.sashimi.member.presentation.api.response.CertificateResponse;
 
 public interface CertificateCommandUseCase {
 
-    void registerCertificate(RegisterCertificateCommand command);
+    CertificateResponse registerCertificate(RegisterCertificateCommand command);
 
     void deleteCertificate(DeleteCertificateCommand command);
 }

--- a/src/main/java/com/sashimi/member/presentation/CertificateController.java
+++ b/src/main/java/com/sashimi/member/presentation/CertificateController.java
@@ -4,6 +4,7 @@ import com.sashimi.member.application.command.DeleteCertificateCommand;
 import com.sashimi.member.application.command.RegisterCertificateCommand;
 import com.sashimi.member.application.usecase.CertificateCommandUseCase;
 import com.sashimi.member.presentation.api.response.ApiResponse;
+import com.sashimi.member.presentation.api.response.CertificateResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
@@ -17,23 +18,21 @@ public class CertificateController {
 
     private final CertificateCommandUseCase certificateCommandUseCase;
 
-    // 자격증 등록
     @PostMapping(value = "/{userId}/certificates", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
-    public ResponseEntity<ApiResponse<Void>> registerCertificate(
+    public ResponseEntity<ApiResponse<CertificateResponse>> registerCertificate(
             @PathVariable Long userId,
             @RequestPart("file") MultipartFile file
     ) throws Exception {
-        certificateCommandUseCase.registerCertificate(
+        CertificateResponse response = certificateCommandUseCase.registerCertificate(
                 new RegisterCertificateCommand(
                         userId,
                         file.getBytes(),
                         file.getOriginalFilename()
                 )
         );
-        return ResponseEntity.ok(ApiResponse.of("자격증이 등록되었습니다."));
+        return ResponseEntity.ok(ApiResponse.of("자격증이 등록되었습니다.", response));
     }
 
-    // 자격증 삭제
     @DeleteMapping("/{userId}/certificates/{certificationId}")
     public ResponseEntity<ApiResponse<Void>> deleteCertificate(
             @PathVariable Long userId,


### PR DESCRIPTION
## 📌 PR 요약
- 자격증 등록 성공 시 등록된 자격증 정보(id, 자격증명, 발급기관, 발급일 등)를 응답으로 반환

---

## 🛠️ 작업 상세 내용 (체크로 선택)
- [ ] ✨ FEATURE
- [ ] 🔧 UPDATE
- [ ] 🐛 BUGFIX
- [ ] ♻️ REFACTOR
- [ ] 📝 DOCS

---

## 📋 작업 상세 내용
- CertificateCommandUseCase 반환 타입 변경 (void → CertificateResponse)


---

## 🔗 PR 관련 이슈로 닫기
Closes #95 

---

## ✅ 체크리스트 (확인 절차)
- [ ] 정상적으로 빌드 및 실행됩니다.
- [ ] 주요 기능이 정상 동작합니다.
- [ ] 불필요한 코드를 제거했습니다.
- [ ] 코드 리뷰 준비가 완료되었습니다.

---

## 💬 리뷰어에게 할 말
- 
<img width="1419" height="1377" alt="image" src="https://github.com/user-attachments/assets/8679d8eb-d77c-41af-941f-5ab9fa09e597" />


---