### PR TITLE
[UPDATE] #111 강사 신청 OCR 검증 연동 및 관리자 대기 목록 조회 API 추가

### DIFF
--- a/src/main/java/com/sashimi/member/application/command/ApplyInstructorCommand.java
+++ b/src/main/java/com/sashimi/member/application/command/ApplyInstructorCommand.java
@@ -3,7 +3,8 @@ package com.sashimi.member.application.command;
 public record ApplyInstructorCommand(
         Long userId,
         String bio,
-        String career,
-        String portfolioUrl
+        String portfolioUrl,
+        byte[] fileBytes,
+        String fileName
 ) {
 }

--- a/src/main/java/com/sashimi/member/application/service/MemberCommandService.java
+++ b/src/main/java/com/sashimi/member/application/service/MemberCommandService.java
@@ -3,6 +3,7 @@ package com.sashimi.member.application.service;
 import com.sashimi.global.exception.BusinessException;
 import com.sashimi.global.exception.ErrorCode;
 import com.sashimi.member.application.command.ApplyInstructorCommand;
+import com.sashimi.member.application.port.OcrPort;
 import com.sashimi.member.application.usecase.MemberCommandUseCase;
 import com.sashimi.member.domain.model.ApprovalStatus;
 import com.sashimi.member.domain.model.InstructorApplication;
@@ -17,25 +18,27 @@ import org.springframework.transaction.annotation.Transactional;
 public class MemberCommandService implements MemberCommandUseCase {
 
     private final InstructorApplicationRepository instructorApplicationRepository;
+    private final OcrPort ocrPort;
 
     @Override
     public void applyInstructor(ApplyInstructorCommand command) {
 
-        // 필수값 검증
         if (command.bio() == null || command.bio().isBlank()) {
-            throw new BusinessException(ErrorCode.INVALID_INPUT);
-        }
-        if (command.career() == null || command.career().isBlank()) {
             throw new BusinessException(ErrorCode.INVALID_INPUT);
         }
         if (command.portfolioUrl() == null || command.portfolioUrl().isBlank()) {
             throw new BusinessException(ErrorCode.INVALID_INPUT);
         }
 
+        // OCR 검증
+        OcrPort.OcrResult result = ocrPort.extractCertificateInfo(command.fileBytes(), command.fileName());
+        if (!result.success()) {
+            throw new BusinessException(ErrorCode.CERTIFICATE_OCR_FAILED);
+        }
+
         // 중복 신청 방지
         boolean alreadyApplied = instructorApplicationRepository
                 .existsByUserIdAndApprovalStatus(command.userId(), ApprovalStatus.PENDING);
-
         if (alreadyApplied) {
             throw new BusinessException(ErrorCode.ALREADY_APPLIED);
         }
@@ -43,8 +46,9 @@ public class MemberCommandService implements MemberCommandUseCase {
         InstructorApplication application = InstructorApplication.create(
                 command.userId(),
                 command.bio(),
-                command.career(),
-                command.portfolioUrl()
+                command.portfolioUrl(),
+                result.certificationName(),
+                result.issuedBy()
         );
 
         instructorApplicationRepository.save(application);
@@ -55,7 +59,6 @@ public class MemberCommandService implements MemberCommandUseCase {
         InstructorApplication application = instructorApplicationRepository
                 .findById(applicationId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.APPLICATION_NOT_FOUND));
-
         application.approve();
         instructorApplicationRepository.save(application);
     }
@@ -65,7 +68,6 @@ public class MemberCommandService implements MemberCommandUseCase {
         InstructorApplication application = instructorApplicationRepository
                 .findById(applicationId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.APPLICATION_NOT_FOUND));
-
         application.reject();
         instructorApplicationRepository.save(application);
     }

--- a/src/main/java/com/sashimi/member/application/service/MemberQueryService.java
+++ b/src/main/java/com/sashimi/member/application/service/MemberQueryService.java
@@ -1,0 +1,27 @@
+package com.sashimi.member.application.service;
+
+import com.sashimi.member.application.usecase.MemberQueryUseCase;
+import com.sashimi.member.domain.model.ApprovalStatus;
+import com.sashimi.member.domain.repository.InstructorApplicationRepository;
+import com.sashimi.member.presentation.api.response.InstructorApplicationResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class MemberQueryService implements MemberQueryUseCase {
+
+    private final InstructorApplicationRepository instructorApplicationRepository;
+
+    @Override
+    public List<InstructorApplicationResponse> getPendingInstructorApplications() {
+        return instructorApplicationRepository.findAllByStatus(ApprovalStatus.PENDING)
+                .stream()
+                .map(InstructorApplicationResponse::from)
+                .toList();
+    }
+}

--- a/src/main/java/com/sashimi/member/application/usecase/MemberQueryUseCase.java
+++ b/src/main/java/com/sashimi/member/application/usecase/MemberQueryUseCase.java
@@ -1,0 +1,10 @@
+package com.sashimi.member.application.usecase;
+
+import com.sashimi.member.presentation.api.response.InstructorApplicationResponse;
+
+import java.util.List;
+
+public interface MemberQueryUseCase {
+
+    List<InstructorApplicationResponse> getPendingInstructorApplications();
+}

--- a/src/main/java/com/sashimi/member/domain/model/InstructorApplication.java
+++ b/src/main/java/com/sashimi/member/domain/model/InstructorApplication.java
@@ -14,19 +14,21 @@ public class InstructorApplication {
     private Long id;
     private Long userId;
     private String bio;
-    private String career;
     private String portfolioUrl;
+    private String certificationName;
+    private String issuedBy;
     private ApprovalStatus approvalStatus;
     private LocalDateTime approvedAt;
     private LocalDateTime createdAt;
     private LocalDateTime updatedAt;
 
-    public static InstructorApplication create(Long userId, String bio, String career, String portfolioUrl) {
+    public static InstructorApplication create(Long userId, String bio, String portfolioUrl, String certificationName, String issuedBy) {
         return InstructorApplication.builder()
                 .userId(userId)
                 .bio(bio)
-                .career(career)
                 .portfolioUrl(portfolioUrl)
+                .certificationName(certificationName)
+                .issuedBy(issuedBy)
                 .approvalStatus(ApprovalStatus.PENDING)
                 .createdAt(LocalDateTime.now())
                 .build();

--- a/src/main/java/com/sashimi/member/infrastructure/persistence/InstructorApplicationJpaEntity.java
+++ b/src/main/java/com/sashimi/member/infrastructure/persistence/InstructorApplicationJpaEntity.java
@@ -18,44 +18,49 @@ public class InstructorApplicationJpaEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "instructorProfileId")
+    @Column(name = "instructor_profile_id")
     private Long id;
 
-    @Column(name = "userId", nullable = false)
+    @Column(name = "user_id", nullable = false)
     private Long userId;
 
     @Column(name = "bio", columnDefinition = "TEXT")
     private String bio;
 
-    @Column(name = "career", columnDefinition = "TEXT")
-    private String career;
-
-    @Column(name = "portfolioUrl")
+    @Column(name = "portfolio_url")
     private String portfolioUrl;
 
+    @Column(name = "certification_name")
+    private String certificationName;
+
+    @Column(name = "issued_by")
+    private String issuedBy;
+
     @Enumerated(EnumType.STRING)
-    @Column(name = "approvalStatus")
+    @Column(name = "approval_status")
     private ApprovalStatus approvalStatus;
 
-    @Column(name = "approvedAt")
+    @Column(name = "approved_at")
     private LocalDateTime approvedAt;
 
-    @Column(name = "createdAt")
+    @Column(name = "created_at")
     private LocalDateTime createdAt;
 
-    @Column(name = "updatedAt")
+    @Column(name = "updated_at")
     private LocalDateTime updatedAt;
 
     @Builder
-    public InstructorApplicationJpaEntity(Long id, Long userId, String bio, String career,
-                                          String portfolioUrl, ApprovalStatus approvalStatus,
+    public InstructorApplicationJpaEntity(Long id, Long userId, String bio,
+                                          String portfolioUrl, String certificationName,
+                                          String issuedBy, ApprovalStatus approvalStatus,
                                           LocalDateTime approvedAt, LocalDateTime createdAt,
                                           LocalDateTime updatedAt) {
         this.id = id;
         this.userId = userId;
         this.bio = bio;
-        this.career = career;
         this.portfolioUrl = portfolioUrl;
+        this.certificationName = certificationName;
+        this.issuedBy = issuedBy;
         this.approvalStatus = approvalStatus;
         this.approvedAt = approvedAt;
         this.createdAt = createdAt;
@@ -67,8 +72,9 @@ public class InstructorApplicationJpaEntity {
                 .id(domain.getId())
                 .userId(domain.getUserId())
                 .bio(domain.getBio())
-                .career(domain.getCareer())
                 .portfolioUrl(domain.getPortfolioUrl())
+                .certificationName(domain.getCertificationName())
+                .issuedBy(domain.getIssuedBy())
                 .approvalStatus(domain.getApprovalStatus())
                 .approvedAt(domain.getApprovedAt())
                 .createdAt(domain.getCreatedAt())
@@ -81,8 +87,9 @@ public class InstructorApplicationJpaEntity {
                 .id(id)
                 .userId(userId)
                 .bio(bio)
-                .career(career)
                 .portfolioUrl(portfolioUrl)
+                .certificationName(certificationName)
+                .issuedBy(issuedBy)
                 .approvalStatus(approvalStatus)
                 .approvedAt(approvedAt)
                 .createdAt(createdAt)

--- a/src/main/java/com/sashimi/member/presentation/MemberController.java
+++ b/src/main/java/com/sashimi/member/presentation/MemberController.java
@@ -2,11 +2,16 @@ package com.sashimi.member.presentation;
 
 import com.sashimi.member.application.command.ApplyInstructorCommand;
 import com.sashimi.member.application.usecase.MemberCommandUseCase;
-import com.sashimi.member.presentation.api.request.ApplyInstructorRequest;
+import com.sashimi.member.application.usecase.MemberQueryUseCase;
 import com.sashimi.member.presentation.api.response.ApiResponse;
+import com.sashimi.member.presentation.api.response.InstructorApplicationResponse;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
 
 @RestController
 @RequestMapping("/api/members")
@@ -14,32 +19,42 @@ import org.springframework.web.bind.annotation.*;
 public class MemberController {
 
     private final MemberCommandUseCase memberCommandUseCase;
+    private final MemberQueryUseCase memberQueryUseCase;
 
-    // 강사 신청
-    @PostMapping("/{userId}/instructor-apply")
+    @PostMapping(value = "/{userId}/instructor-apply", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ResponseEntity<ApiResponse<Void>> applyInstructor(
             @PathVariable Long userId,
-            @RequestBody ApplyInstructorRequest request
-    ) {
+            @RequestPart("bio") String bio,
+            @RequestPart("portfolioUrl") String portfolioUrl,
+            @RequestPart("file") MultipartFile file
+    ) throws Exception {
         memberCommandUseCase.applyInstructor(
-                new ApplyInstructorCommand(userId, request.bio(), request.career(), request.portfolioUrl())
+                new ApplyInstructorCommand(
+                        userId,
+                        bio,
+                        portfolioUrl,
+                        file.getBytes(),
+                        file.getOriginalFilename()
+                )
         );
-        return ResponseEntity.ok(
-                ApiResponse.of("강사 지원이 완료되었습니다. 결과는 사내 평가 후 이메일을 통해 일주일 이내에 발송됩니다.")
-        );
+        return ResponseEntity.ok(ApiResponse.of("강사 지원이 완료되었습니다. 결과는 사내 평가 후 이메일을 통해 일주일 이내에 발송됩니다."));
     }
 
-    // 강사 승인 (관리자)
     @PatchMapping("/instructor-applications/{applicationId}/approve")
     public ResponseEntity<ApiResponse<Void>> approveInstructor(@PathVariable Long applicationId) {
         memberCommandUseCase.approveInstructor(applicationId);
         return ResponseEntity.ok(ApiResponse.of("강사 요청을 승인했습니다."));
     }
 
-    // 강사 반려 (관리자)
     @PatchMapping("/instructor-applications/{applicationId}/reject")
     public ResponseEntity<ApiResponse<Void>> rejectInstructor(@PathVariable Long applicationId) {
         memberCommandUseCase.rejectInstructor(applicationId);
         return ResponseEntity.ok(ApiResponse.of("강사 요청을 반려했습니다."));
+    }
+
+    @GetMapping("/instructor-applications/pending")
+    public ResponseEntity<ApiResponse<List<InstructorApplicationResponse>>> getPendingInstructorApplications() {
+        List<InstructorApplicationResponse> responses = memberQueryUseCase.getPendingInstructorApplications();
+        return ResponseEntity.ok(ApiResponse.of("강사 신청 대기 목록 조회 성공", responses));
     }
 }

--- a/src/main/java/com/sashimi/member/presentation/api/request/ApplyInstructorRequest.java
+++ b/src/main/java/com/sashimi/member/presentation/api/request/ApplyInstructorRequest.java
@@ -2,7 +2,6 @@ package com.sashimi.member.presentation.api.request;
 
 public record ApplyInstructorRequest(
         String bio,
-        String career,
         String portfolioUrl
 ) {
 }

--- a/src/main/java/com/sashimi/member/presentation/api/response/InstructorApplicationResponse.java
+++ b/src/main/java/com/sashimi/member/presentation/api/response/InstructorApplicationResponse.java
@@ -9,8 +9,9 @@ public record InstructorApplicationResponse(
         Long id,
         Long userId,
         String bio,
-        String career,
         String portfolioUrl,
+        String certificationName,
+        String issuedBy,
         ApprovalStatus approvalStatus,
         LocalDateTime approvedAt,
         LocalDateTime createdAt
@@ -20,8 +21,9 @@ public record InstructorApplicationResponse(
                 domain.getId(),
                 domain.getUserId(),
                 domain.getBio(),
-                domain.getCareer(),
                 domain.getPortfolioUrl(),
+                domain.getCertificationName(),
+                domain.getIssuedBy(),
                 domain.getApprovalStatus(),
                 domain.getApprovedAt(),
                 domain.getCreatedAt()

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -243,10 +243,10 @@ VALUES
 
 -- 더미 데이터
 INSERT INTO instructor_profiles
-(bio, career, certifications, portfolio_url, approval_status, approved_at, user_id)
+(bio, portfolio_url, certification_name, issued_by, approval_status, approved_at, user_id)
 VALUES
-    ('정보처리기사와 SQLD 자격증 강의를 전문으로 합니다.', '소프트웨어 개발 7년, 자격증 교육 3년', '정보처리기사, SQLD', 'https://portfolio.example.com/instructor1', 'APPROVED', NOW(), 2),
-    ('데이터 분석 자격증과 빅데이터분석기사 강의를 진행합니다.', '데이터 분석 프로젝트 5년, 자격증 교육 다수', 'ADsP, 빅데이터분석기사', 'https://portfolio.example.com/instructor2', 'APPROVED', NOW(), 3);
+    ('정보처리기사와 SQLD 자격증 강의를 전문으로 합니다.', 'https://portfolio.example.com/instructor1', '정보처리기사', '한국산업인력공단', 'APPROVED', NOW(), 2),
+    ('데이터 분석 자격증과 빅데이터분석기사 강의를 진행합니다.', 'https://portfolio.example.com/instructor2', 'ADsP', '한국데이터산업진흥원', 'APPROVED', NOW(), 3);
 
 INSERT INTO instructor_bank_accounts
 (bank_name, account_number, account_holder, is_primary, verification_status, user_id)

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -328,9 +328,9 @@ CREATE TABLE credits (
 CREATE TABLE instructor_profiles (
                                      instructor_profile_id BIGINT AUTO_INCREMENT PRIMARY KEY,
                                      bio TEXT,
-                                     career TEXT,
-                                     certifications TEXT,
                                      portfolio_url VARCHAR(500),
+                                     certification_name VARCHAR(255),
+                                     issued_by VARCHAR(255),
                                      approval_status ENUM('PENDING', 'APPROVED', 'REJECTED') NOT NULL DEFAULT 'PENDING',
                                      approved_at DATETIME NULL,
                                      created_at DATETIME DEFAULT NOW(),


### PR DESCRIPTION
## 📌 PR 요약
- 강사 신청 시 자격증 PDF 업로드 → Clova OCR 자동 검증 연동
- 관리자 강사 신청 대기 목록 조회 API 추가
- 강사 신청 필드 변경 (career 제거, 자격증 파일 추가)

---

## 🛠️ 작업 상세 내용 (체크로 선택)
- [ ] ✨ FEATURE
- [ ] 🔧 UPDATE
- [ ] 🐛 BUGFIX
- [ ] ♻️ REFACTOR
- [ ] 📝 DOCS

---

## 📋 작업 상세 내용
- 
- 
- 

---

## 🔗 PR 관련 이슈로 닫기
Closes #111 

---

## ✅ 체크리스트 (확인 절차)
- [ ] 정상적으로 빌드 및 실행됩니다.
- [ ] 주요 기능이 정상 동작합니다.
- [ ] 불필요한 코드를 제거했습니다.
- [ ] 코드 리뷰 준비가 완료되었습니다.

---

## 💬 리뷰어에게 할 말
- 
<img width="1404" height="908" alt="image" src="https://github.com/user-attachments/assets/5a546014-f5b4-485d-a403-a293f9f1ff36" />
<img width="1414" height="853" alt="image" src="https://github.com/user-attachments/assets/94956b75-40bb-49a2-904e-d87f5aa5e426" />


---