### PR TITLE
[UPDATE] #135 #136 채용공고 AI 분석 비동기 처리 및 조회 API 정리

### DIFF
--- a/src/main/java/com/sashimi/LmsApplication.java
+++ b/src/main/java/com/sashimi/LmsApplication.java
@@ -2,8 +2,10 @@ package com.sashimi;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableAsync;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
+@EnableAsync
 @EnableScheduling
 @SpringBootApplication
 public class LmsApplication {

--- a/src/main/java/com/sashimi/recommendation/application/service/JobPostingRecommendationAsyncService.java
+++ b/src/main/java/com/sashimi/recommendation/application/service/JobPostingRecommendationAsyncService.java
@@ -1,0 +1,87 @@
+package com.sashimi.recommendation.application.service;
+
+import com.sashimi.ai.domain.model.AiPrompt;
+import com.sashimi.ai.domain.model.AiPromptType;
+import com.sashimi.ai.domain.repository.AiPromptRepository;
+import com.sashimi.global.exception.BusinessException;
+import com.sashimi.global.exception.ErrorCode;
+import com.sashimi.recommendation.application.event.JobPostingRecommendationAnalyzedEvent;
+import com.sashimi.recommendation.application.port.JobPostingRecommendationAnalyzePort;
+import com.sashimi.recommendation.application.port.JobPostingRecommendationAnalyzeResult;
+import com.sashimi.recommendation.domain.model.JobPostingRecommendation;
+import com.sashimi.recommendation.domain.repository.JobPostingRecommendationRepository;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+public class JobPostingRecommendationAsyncService {
+
+    private final JobPostingRecommendationRepository recommendationRepository;
+    private final JobPostingRecommendationAnalyzePort analyzePort;
+    private final AiPromptRepository aiPromptRepository;
+    private final ApplicationEventPublisher eventPublisher;
+
+    public JobPostingRecommendationAsyncService(
+            JobPostingRecommendationRepository recommendationRepository,
+            JobPostingRecommendationAnalyzePort analyzePort,
+            AiPromptRepository aiPromptRepository,
+            ApplicationEventPublisher eventPublisher
+    ) {
+        this.recommendationRepository = recommendationRepository;
+        this.analyzePort = analyzePort;
+        this.aiPromptRepository = aiPromptRepository;
+        this.eventPublisher = eventPublisher;
+    }
+
+    @Async
+    @Transactional
+    public void analyze(Long recommendationId, Long userId) {
+        log.info("🗃️ 채용공고 추천 비동기 분석 시작: userId={}, recommendationId={}", userId, recommendationId);
+
+        JobPostingRecommendation recommendation = recommendationRepository.findByIdAndUserId(recommendationId, userId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.JOB_POSTING_RECOMMENDATION_NOT_FOUND));
+
+        try {
+            AiPrompt prompt = aiPromptRepository.findActiveByType(AiPromptType.JOB_POSTING_ANALYSIS)
+                    .orElseThrow(() -> new BusinessException(ErrorCode.AI_PROMPT_NOT_FOUND));
+
+            JobPostingRecommendationAnalyzeResult analyzeResult = analyzePort.analyze(recommendation, prompt);
+
+            JobPostingRecommendation analyzedRecommendation = recommendation.analyzed(
+                    analyzeResult.jobTitle(),
+                    analyzeResult.matchRate(),
+                    analyzeResult.requiredSkills(),
+                    analyzeResult.courses(),
+                    analyzeResult.certificates()
+            );
+
+            JobPostingRecommendation savedRecommendation = recommendationRepository.save(analyzedRecommendation);
+
+            log.info("🗃️ 채용공고 추천 비동기 분석 완료: userId={}, recommendationId={}, jobTitle={}, matchRate={}",
+                    savedRecommendation.userId(),
+                    savedRecommendation.recommendationId(),
+                    savedRecommendation.jobTitle(),
+                    savedRecommendation.matchRate());
+
+            eventPublisher.publishEvent(
+                    new JobPostingRecommendationAnalyzedEvent(
+                            savedRecommendation.userId(),
+                            savedRecommendation.recommendationId(),
+                            savedRecommendation.jobTitle(),
+                            savedRecommendation.matchRate(),
+                            savedRecommendation.createdAt()
+                    )
+            );
+
+        } catch (Exception e) {
+            log.error("🗃️ 채용공고 AI 분석 실패. recommendationId={}, userId={}", recommendationId, userId, e);
+
+            JobPostingRecommendation failedRecommendation = recommendation.failed();
+            recommendationRepository.save(failedRecommendation);
+        }
+    }
+}

--- a/src/main/java/com/sashimi/recommendation/application/service/JobPostingRecommendationService.java
+++ b/src/main/java/com/sashimi/recommendation/application/service/JobPostingRecommendationService.java
@@ -1,28 +1,16 @@
 package com.sashimi.recommendation.application.service;
 
-import com.sashimi.ai.domain.model.AiPrompt;
-import com.sashimi.ai.domain.model.AiPromptType;
-import com.sashimi.ai.domain.repository.AiPromptRepository;
 import com.sashimi.global.exception.BusinessException;
 import com.sashimi.global.exception.ErrorCode;
 import com.sashimi.recommendation.application.command.CreateJobPostingRecommendationCommand;
-import com.sashimi.recommendation.application.event.JobPostingRecommendationAnalyzedEvent;
 import com.sashimi.recommendation.application.policy.JobPostingRecommendationPolicy;
-import com.sashimi.recommendation.application.port.JobPostingRecommendationAnalyzePort;
-import com.sashimi.recommendation.application.port.JobPostingRecommendationAnalyzeResult;
 import com.sashimi.recommendation.application.usecase.JobPostingRecommendationCommandUseCase;
 import com.sashimi.recommendation.application.usecase.JobPostingRecommendationQueryUseCase;
-import com.sashimi.recommendation.domain.model.CertificateRecommendation;
-import com.sashimi.recommendation.domain.model.CourseRecommendation;
 import com.sashimi.recommendation.domain.model.JobPostingRecommendation;
-import com.sashimi.recommendation.domain.model.RequiredSkillRecommendation;
 import com.sashimi.recommendation.domain.repository.JobPostingRecommendationRepository;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.util.List;
 
 @Slf4j
 @Service
@@ -31,29 +19,23 @@ public class JobPostingRecommendationService implements
         JobPostingRecommendationQueryUseCase {
 
     private final JobPostingRecommendationRepository recommendationRepository;
-    private final JobPostingRecommendationAnalyzePort analyzePort;
     private final JobPostingRecommendationPolicy recommendationPolicy;
-    private final AiPromptRepository aiPromptRepository;
-    private final ApplicationEventPublisher eventPublisher;
+    private final JobPostingRecommendationAsyncService asyncService;
 
     public JobPostingRecommendationService(
             JobPostingRecommendationRepository recommendationRepository,
-            JobPostingRecommendationAnalyzePort analyzePort,
             JobPostingRecommendationPolicy recommendationPolicy,
-            AiPromptRepository aiPromptRepository,
-            ApplicationEventPublisher eventPublisher
+            JobPostingRecommendationAsyncService asyncService
     ) {
         this.recommendationRepository = recommendationRepository;
-        this.analyzePort = analyzePort;
         this.recommendationPolicy = recommendationPolicy;
-        this.aiPromptRepository = aiPromptRepository;
-        this.eventPublisher = eventPublisher;
+        this.asyncService = asyncService;
     }
 
     @Override
     @Transactional
     public JobPostingRecommendation create(CreateJobPostingRecommendationCommand command) {
-        log.info("🗃️ 채용공고 추천 요청: userId={}, inputType={}, hasSourceUrl={}, rawContentLength={}",
+        log.info("채용공고 추천 요청 접수: userId={}, inputType={}, hasSourceUrl={}, rawContentLength={}",
                 command.userId(),
                 command.inputType(),
                 command.sourceUrl() != null,
@@ -71,67 +53,40 @@ public class JobPostingRecommendationService implements
 
         JobPostingRecommendation savedRecommendation = recommendationRepository.save(recommendation);
 
-        log.info("🗃️ 채용공고 추천 생성: userId={}, recommendationId={}, resumeBased={}",
+        log.info("채용공고 추천 분석 대기 상태 저장: userId={}, recommendationId={}, resumeBased={}, analysisStatus={}",
                 savedRecommendation.userId(),
                 savedRecommendation.recommendationId(),
-                savedRecommendation.resumeBased());
+                savedRecommendation.resumeBased(),
+                savedRecommendation.analysisStatus());
 
-        AiPrompt prompt = aiPromptRepository.findActiveByType(AiPromptType.JOB_POSTING_ANALYSIS)
-                .orElseThrow(() -> new BusinessException(ErrorCode.AI_PROMPT_NOT_FOUND));
-
-        JobPostingRecommendationAnalyzeResult analyzeResult = analyzePort.analyze(savedRecommendation, prompt);
-
-        JobPostingRecommendation analyzedRecommendation = savedRecommendation.analyzed(
-                analyzeResult.jobTitle(),
-                analyzeResult.matchRate(),
-                analyzeResult.requiredSkills(),
-                analyzeResult.courses(),
-                analyzeResult.certificates()
+        asyncService.analyze(
+                savedRecommendation.recommendationId(),
+                savedRecommendation.userId()
         );
 
-        JobPostingRecommendation savedAnalyzedRecommendation = recommendationRepository.save(analyzedRecommendation);
+        log.debug("채용공고 추천 비동기 분석 요청 발행: userId={}, recommendationId={}",
+                savedRecommendation.userId(),
+                savedRecommendation.recommendationId());
 
-        log.debug("🗃️ 채용공고 추천 분석 저장: userId={}, recommendationId={}",
-                savedAnalyzedRecommendation.userId(),
-                savedAnalyzedRecommendation.recommendationId());
-
-        eventPublisher.publishEvent(
-                new JobPostingRecommendationAnalyzedEvent(
-                        savedAnalyzedRecommendation.userId(),
-                        savedAnalyzedRecommendation.recommendationId(),
-                        savedAnalyzedRecommendation.jobTitle(),
-                        savedAnalyzedRecommendation.matchRate(),
-                        savedAnalyzedRecommendation.createdAt()
-                )
-        );
-
-        return savedAnalyzedRecommendation;
+        return savedRecommendation;
     }
 
     @Override
     @Transactional(readOnly = true)
-    public JobPostingRecommendation getLatest(Long userId) {
-        log.debug("🗃️ 채용공고 추천 조회: userId={}", userId);
+    public JobPostingRecommendation getById(Long userId, Long recommendationId) {
+        log.debug("채용공고 추천 단건 조회 요청: userId={}, recommendationId={}", userId, recommendationId);
 
-        return recommendationRepository.findLatestByUserId(userId)
-                .orElseThrow(() -> new BusinessException(ErrorCode.JOB_POSTING_RECOMMENDATION_NOT_FOUND));
-    }
+        JobPostingRecommendation recommendation = recommendationRepository.findByIdAndUserId(recommendationId, userId)
+                .orElseThrow(() -> {
+                    log.warn("채용공고 추천 단건 조회 실패: userId={}, recommendationId={}", userId, recommendationId);
+                    return new BusinessException(ErrorCode.JOB_POSTING_RECOMMENDATION_NOT_FOUND);
+                });
 
-    @Override
-    @Transactional(readOnly = true)
-    public List<RequiredSkillRecommendation> getLatestSkills(Long userId) {
-        return getLatest(userId).requiredSkills();
-    }
+        log.debug("채용공고 추천 단건 조회 성공: userId={}, recommendationId={}, analysisStatus={}",
+                recommendation.userId(),
+                recommendation.recommendationId(),
+                recommendation.analysisStatus());
 
-    @Override
-    @Transactional(readOnly = true)
-    public List<CourseRecommendation> getLatestCourses(Long userId) {
-        return getLatest(userId).courses();
-    }
-
-    @Override
-    @Transactional(readOnly = true)
-    public List<CertificateRecommendation> getLatestCertificates(Long userId) {
-        return getLatest(userId).certificates();
+        return recommendation;
     }
 }

--- a/src/main/java/com/sashimi/recommendation/application/usecase/JobPostingRecommendationQueryUseCase.java
+++ b/src/main/java/com/sashimi/recommendation/application/usecase/JobPostingRecommendationQueryUseCase.java
@@ -1,19 +1,8 @@
 package com.sashimi.recommendation.application.usecase;
 
-import com.sashimi.recommendation.domain.model.CertificateRecommendation;
-import com.sashimi.recommendation.domain.model.CourseRecommendation;
 import com.sashimi.recommendation.domain.model.JobPostingRecommendation;
-import com.sashimi.recommendation.domain.model.RequiredSkillRecommendation;
-
-import java.util.List;
 
 public interface JobPostingRecommendationQueryUseCase {
 
-    JobPostingRecommendation getLatest(Long userId);
-
-    List<RequiredSkillRecommendation> getLatestSkills(Long userId);
-
-    List<CourseRecommendation> getLatestCourses(Long userId);
-
-    List<CertificateRecommendation> getLatestCertificates(Long userId);
+    JobPostingRecommendation getById(Long userId, Long recommendationId);
 }

--- a/src/main/java/com/sashimi/recommendation/domain/model/JobPostingRecommendation.java
+++ b/src/main/java/com/sashimi/recommendation/domain/model/JobPostingRecommendation.java
@@ -97,6 +97,24 @@ public class JobPostingRecommendation {
         );
     }
 
+    public JobPostingRecommendation failed() {
+        return new JobPostingRecommendation(
+                recommendationId,
+                userId,
+                inputType,
+                sourceUrl,
+                rawContent,
+                jobTitle,
+                RecommendationAnalysisStatus.FAILED,
+                resumeBased,
+                matchRate,
+                requiredSkills,
+                courses,
+                certificates,
+                createdAt
+        );
+    }
+
     public JobPostingRecommendation withId(Long recommendationId) {
         return new JobPostingRecommendation(
                 recommendationId,

--- a/src/main/java/com/sashimi/recommendation/presentation/api/JobPostingRecommendationController.java
+++ b/src/main/java/com/sashimi/recommendation/presentation/api/JobPostingRecommendationController.java
@@ -1,29 +1,23 @@
 package com.sashimi.recommendation.presentation.api;
 
+import com.sashimi.global.exception.ErrorResponse;
 import com.sashimi.recommendation.application.command.CreateJobPostingRecommendationCommand;
 import com.sashimi.recommendation.application.usecase.JobPostingRecommendationCommandUseCase;
 import com.sashimi.recommendation.application.usecase.JobPostingRecommendationQueryUseCase;
 import com.sashimi.recommendation.domain.model.JobPostingRecommendation;
 import com.sashimi.recommendation.presentation.api.request.CreateJobPostingRecommendationRequest;
-import com.sashimi.recommendation.presentation.api.response.CertificateRecommendationResponse;
-import com.sashimi.recommendation.presentation.api.response.CourseRecommendationResponse;
 import com.sashimi.recommendation.presentation.api.response.JobPostingRecommendationResponse;
-import com.sashimi.recommendation.presentation.api.response.RequiredSkillRecommendationResponse;
 import com.sashimi.security.principal.CustomUserPrincipal;
-import org.springframework.http.HttpStatus;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.*;
-import com.sashimi.global.exception.ErrorResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
-import io.swagger.v3.oas.annotations.media.ArraySchema;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
-
-import java.util.List;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
 
 @Tag(name = "Job Posting Recommendation", description = "채용공고 기반 AI 추천 API")
 @RestController
@@ -42,25 +36,21 @@ public class JobPostingRecommendationController {
     }
 
     @Operation(
-            summary = "채용공고 기반 추천 생성",
-            description = "채용공고 URL 또는 텍스트를 기반으로 AI 분석을 수행하고 추천 요약 결과를 생성합니다."
+            summary = "채용공고 기반 추천 요청",
+            description = "채용공고 내용을 저장하고 AI 분석을 비동기로 요청합니다. 응답은 PENDING 상태로 반환되며, 분석 결과는 단건 조회 API로 확인합니다."
     )
     @ApiResponses({
-            @ApiResponse(responseCode = "201", description = "채용공고 기반 추천 생성 성공",
+            @ApiResponse(responseCode = "202", description = "채용공고 기반 추천 요청 접수 성공",
                     content = @Content(schema = @Schema(implementation = JobPostingRecommendationResponse.class))),
             @ApiResponse(responseCode = "400", description = "잘못된 요청 또는 입력값 오류",
                     content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
             @ApiResponse(responseCode = "401", description = "인증 실패",
                     content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
-            @ApiResponse(responseCode = "404", description = "활성화된 AI 프롬프트를 찾을 수 없음",
-                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
-            @ApiResponse(responseCode = "500", description = "AI API Key 설정 오류 또는 서버 오류",
-                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
-            @ApiResponse(responseCode = "502", description = "AI API 호출 실패 또는 AI 응답 파싱 실패",
+            @ApiResponse(responseCode = "500", description = "서버 오류",
                     content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
     })
     @PostMapping
-    @ResponseStatus(HttpStatus.CREATED)
+    @ResponseStatus(HttpStatus.ACCEPTED)
     public JobPostingRecommendationResponse create(
             @Parameter(hidden = true)
             @AuthenticationPrincipal CustomUserPrincipal principal,
@@ -79,89 +69,28 @@ public class JobPostingRecommendationController {
     }
 
     @Operation(
-            summary = "최신 채용공고 추천 조회",
-            description = "로그인한 사용자의 가장 최근 채용공고 기반 추천 요약 결과를 조회합니다."
+            summary = "채용공고 추천 결과 조회",
+            description = "채용공고 추천 ID로 AI 분석 상태와 결과를 조회합니다. PENDING이면 분석 중이며, COMPLETED이면 요구 역량, 추천 자격증, 추천 강의가 함께 반환됩니다."
     )
     @ApiResponses({
-            @ApiResponse(responseCode = "200", description = "최신 추천 결과 조회 성공",
+            @ApiResponse(responseCode = "200", description = "채용공고 추천 결과 조회 성공",
                     content = @Content(schema = @Schema(implementation = JobPostingRecommendationResponse.class))),
             @ApiResponse(responseCode = "401", description = "인증 실패",
                     content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
             @ApiResponse(responseCode = "404", description = "채용공고 추천 결과를 찾을 수 없음",
                     content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
     })
-    @GetMapping
-    public JobPostingRecommendationResponse getLatest(
+    @GetMapping("/{recommendationId}")
+    public JobPostingRecommendationResponse getById(
             @Parameter(hidden = true)
-            @AuthenticationPrincipal CustomUserPrincipal principal
+            @AuthenticationPrincipal CustomUserPrincipal principal,
+            @PathVariable Long recommendationId
     ) {
-        JobPostingRecommendation recommendation = queryUseCase.getLatest(principal.getId());
+        JobPostingRecommendation recommendation = queryUseCase.getById(
+                principal.getId(),
+                recommendationId
+        );
+
         return JobPostingRecommendationResponse.from(recommendation);
-    }
-
-    @Operation(
-            summary = "채용공고 요구 역량 조회",
-            description = "가장 최근 채용공고 추천 결과에서 추출된 요구 역량 목록을 조회합니다."
-    )
-    @ApiResponses({
-            @ApiResponse(responseCode = "200", description = "요구 역량 조회 성공",
-                    content = @Content(array = @ArraySchema(schema = @Schema(implementation = RequiredSkillRecommendationResponse.class)))),
-            @ApiResponse(responseCode = "401", description = "인증 실패",
-                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
-            @ApiResponse(responseCode = "404", description = "채용공고 추천 결과를 찾을 수 없음",
-                    content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
-    })
-    @GetMapping("/skills")
-    public List<RequiredSkillRecommendationResponse> getSkills(
-            @Parameter(hidden = true)
-            @AuthenticationPrincipal CustomUserPrincipal principal
-    ) {
-        return queryUseCase.getLatestSkills(principal.getId()).stream()
-                .map(RequiredSkillRecommendationResponse::from)
-                .toList();
-    }
-
-    @Operation(
-            summary = "채용공고 기반 추천 강의 조회",
-            description = "가장 최근 채용공고 추천 결과를 기반으로 추천 강의 목록을 조회합니다."
-    )
-    @ApiResponses({
-            @ApiResponse(responseCode = "200", description = "추천 강의 조회 성공",
-                    content = @Content(array = @ArraySchema(schema = @Schema(implementation = CourseRecommendationResponse.class)))),
-            @ApiResponse(responseCode = "401", description = "인증 실패",
-                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
-            @ApiResponse(responseCode = "404", description = "채용공고 추천 결과를 찾을 수 없음",
-                    content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
-    })
-    @GetMapping("/courses")
-    public List<CourseRecommendationResponse> recommendCourses(
-            @Parameter(hidden = true)
-            @AuthenticationPrincipal CustomUserPrincipal principal
-    ) {
-        return queryUseCase.getLatestCourses(principal.getId()).stream()
-                .map(CourseRecommendationResponse::from)
-                .toList();
-    }
-
-    @Operation(
-            summary = "채용공고 기반 추천 자격증 조회",
-            description = "가장 최근 채용공고 추천 결과를 기반으로 추천 자격증 목록을 조회합니다."
-    )
-    @ApiResponses({
-            @ApiResponse(responseCode = "200", description = "추천 자격증 조회 성공",
-                    content = @Content(array = @ArraySchema(schema = @Schema(implementation = CertificateRecommendationResponse.class)))),
-            @ApiResponse(responseCode = "401", description = "인증 실패",
-                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
-            @ApiResponse(responseCode = "404", description = "채용공고 추천 결과를 찾을 수 없음",
-                    content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
-    })
-    @GetMapping("/certificates")
-    public List<CertificateRecommendationResponse> getCertificates(
-            @Parameter(hidden = true)
-            @AuthenticationPrincipal CustomUserPrincipal principal
-    ) {
-        return queryUseCase.getLatestCertificates(principal.getId()).stream()
-                .map(CertificateRecommendationResponse::from)
-                .toList();
     }
 }

--- a/src/main/java/com/sashimi/recommendation/presentation/api/response/JobPostingRecommendationResponse.java
+++ b/src/main/java/com/sashimi/recommendation/presentation/api/response/JobPostingRecommendationResponse.java
@@ -2,11 +2,13 @@ package com.sashimi.recommendation.presentation.api.response;
 
 import com.sashimi.recommendation.domain.model.JobPostingRecommendation;
 import com.sashimi.recommendation.domain.model.RecommendationAnalysisStatus;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
 import io.swagger.v3.oas.annotations.media.Schema;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
-@Schema(description = "채용공고 기반 추천 요약 응답")
+@Schema(description = "채용공고 기반 추천 결과 응답")
 public record JobPostingRecommendationResponse(
 
         @Schema(description = "채용공고 추천 ID", example = "1")
@@ -24,6 +26,24 @@ public record JobPostingRecommendationResponse(
         @Schema(description = "이력서와 채용공고 요구 역량의 일치율. 이력서가 없으면 null", example = "56")
         Integer matchRate,
 
+        @ArraySchema(
+                schema = @Schema(implementation = RequiredSkillRecommendationResponse.class),
+                arraySchema = @Schema(description = "채용공고에서 추출된 요구 역량 목록")
+        )
+        List<RequiredSkillRecommendationResponse> requiredSkills,
+
+        @ArraySchema(
+                schema = @Schema(implementation = CertificateRecommendationResponse.class),
+                arraySchema = @Schema(description = "채용공고 기반 추천 자격증 목록")
+        )
+        List<CertificateRecommendationResponse> certificates,
+
+        @ArraySchema(
+                schema = @Schema(implementation = CourseRecommendationResponse.class),
+                arraySchema = @Schema(description = "역량 보완을 위한 추천 강의 목록")
+        )
+        List<CourseRecommendationResponse> courses,
+
         @Schema(description = "추천 생성일시", example = "2026-05-27T16:30:00")
         LocalDateTime createdAt
 ) {
@@ -34,6 +54,15 @@ public record JobPostingRecommendationResponse(
                 recommendation.analysisStatus(),
                 recommendation.resumeBased(),
                 recommendation.matchRate(),
+                recommendation.requiredSkills().stream()
+                        .map(RequiredSkillRecommendationResponse::from)
+                        .toList(),
+                recommendation.certificates().stream()
+                        .map(CertificateRecommendationResponse::from)
+                        .toList(),
+                recommendation.courses().stream()
+                        .map(CourseRecommendationResponse::from)
+                        .toList(),
                 recommendation.createdAt()
         );
     }


### PR DESCRIPTION
## 📌 PR 요약
채용공고 기반 AI 추천 기능을 화면 흐름에 맞게 개선했습니다.  
AI 분석 요청은 비동기로 처리하고, 분석 결과는 recommendationId 기반 단건 조회로 확인하도록 정리했습니다.


---

## 🛠️ 작업 상세 내용 (체크로 선택)
- [ ] ✨ FEATURE
- [X] 🔧 UPDATE
- [ ] 🐛 BUGFIX
- [ ] ♻️ REFACTOR
- [ ] 📝 DOCS

---

## 📋 작업 상세 내용
- 채용공고 추천 생성 시 `PENDING` 상태로 우선 저장
- AI 분석 처리를 `JobPostingRecommendationAsyncService`로 분리
- AI 분석 성공 시 `COMPLETED`, 실패 시 `FAILED` 상태 저장
- 생성 API 응답 코드를 `202 Accepted`로 변경
- `GET /recommendations/job-posting/{recommendationId}` 중심으로 조회 구조 정리
- 최신 조회 및 개별 목록 조회 API 제거
- `JobPostingRecommendationResponse`에 요구 역량, 추천 자격증, 추천 강의 목록 포함
- Swagger 설명을 비동기 분석 흐름에 맞게 수정

---

## 🔗 PR 관련 이슈로 닫기
Closes #135 , #136

---

## ✅ 체크리스트 (확인 절차)
- [ ] 정상적으로 빌드 및 실행됩니다.
- [ ] 주요 기능이 정상 동작합니다.
- [ ] 불필요한 코드를 제거했습니다.
- [ ] 코드 리뷰 준비가 완료되었습니다.

---

## 💬 리뷰어에게 할 말
- 프론트는 `POST` 응답의 `recommendationId`를 저장한 뒤 단건 조회 API로 상태를 폴링합니다.
- `PENDING` 상태에서는 결과 목록이 빈 배열로 반환되고, `COMPLETED` 상태에서는 한 페이지에 필요한 전체 추천 결과가 반환됩니다.

---