### PR TITLE
[UPDATE] 아키텍처 테스트 도입 - ArchUnit + Port 계약 테스트

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -55,6 +55,7 @@ dependencies {
     testAnnotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-webmvc-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+    testImplementation 'com.tngtech.archunit:archunit-junit5:1.3.0'
 
     implementation 'org.springframework.boot:spring-boot-starter-mail'
 }

--- a/src/test/java/com/sashimi/architecture/CleanArchitectureTest.java
+++ b/src/test/java/com/sashimi/architecture/CleanArchitectureTest.java
@@ -1,0 +1,68 @@
+package com.sashimi.architecture;
+
+import com.tngtech.archunit.core.domain.JavaClasses;
+import com.tngtech.archunit.core.importer.ClassFileImporter;
+import com.tngtech.archunit.core.importer.ImportOption;
+import com.tngtech.archunit.lang.ArchRule;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.noClasses;
+
+@DisplayName("[ArchUnit] 클린 아키텍처 계층 의존성 검증")
+class CleanArchitectureTest {
+
+    private static JavaClasses classes;
+
+    @BeforeAll
+    static void load() {
+        classes = new ClassFileImporter()
+                .withImportOption(ImportOption.Predefined.DO_NOT_INCLUDE_TESTS)
+                .importPackages("com.sashimi");
+    }
+
+    @Test
+    @DisplayName("Domain은 Infrastructure를 의존하지 않는다")
+    void domain_should_not_depend_on_infrastructure() {
+        ArchRule rule = noClasses()
+                .that().resideInAPackage("..domain..")
+                .should().dependOnClassesThat()
+                .resideInAPackage("..infrastructure..");
+
+        rule.check(classes);
+    }
+
+    @Test
+    @DisplayName("Domain은 Presentation을 의존하지 않는다")
+    void domain_should_not_depend_on_presentation() {
+        ArchRule rule = noClasses()
+                .that().resideInAPackage("..domain..")
+                .should().dependOnClassesThat()
+                .resideInAPackage("..presentation..");
+
+        rule.check(classes);
+    }
+
+    @Test
+    @DisplayName("Infrastructure는 Presentation을 의존하지 않는다")
+    void infrastructure_should_not_depend_on_presentation() {
+        ArchRule rule = noClasses()
+                .that().resideInAPackage("..infrastructure..")
+                .should().dependOnClassesThat()
+                .resideInAPackage("..presentation..");
+
+        rule.check(classes);
+    }
+
+    @Test
+    @DisplayName("Presentation은 Infrastructure를 직접 의존하지 않는다")
+    void presentation_should_not_depend_on_infrastructure() {
+        ArchRule rule = noClasses()
+                .that().resideInAPackage("..presentation..")
+                .should().dependOnClassesThat()
+                .resideInAPackage("..infrastructure..");
+
+        rule.check(classes);
+    }
+}

--- a/src/test/java/com/sashimi/credit/application/service/CreditCommandServiceTest.java
+++ b/src/test/java/com/sashimi/credit/application/service/CreditCommandServiceTest.java
@@ -1,0 +1,84 @@
+package com.sashimi.credit.application.service;
+
+import com.sashimi.credit.application.command.GrantReferralSignupRewardCommand;
+import com.sashimi.credit.domain.model.Credit;
+import com.sashimi.credit.domain.repository.CreditRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@DisplayName("추천인 크레딧 지급 테스트")
+class CreditCommandServiceTest {
+
+    private CreditRepository creditRepository;
+    private CreditCommandService creditCommandService;
+
+    @BeforeEach
+    void setUp() {
+        creditRepository = mock(CreditRepository.class);
+        creditCommandService = new CreditCommandService(creditRepository);
+    }
+
+    @Test
+    @DisplayName("추천인 코드로 가입 시 새 유저는 5000 크레딧을 받는다")
+    void newUser_receives_5000_credits_when_signed_up_with_referral_code() {
+        // given
+        Long newUserId = 10L;
+        Long referrerUserId = 1L;
+
+        // 새 유저 크레딧 없음
+        when(creditRepository.findByUserId(newUserId)).thenReturn(Optional.empty());
+        // 추천인 크레딧 존재
+        when(creditRepository.findByUserIdForUpdate(referrerUserId))
+                .thenReturn(Optional.of(Credit.create(referrerUserId, 0L)));
+        when(creditRepository.save(any())).thenAnswer(inv -> inv.getArgument(0));
+
+        // when
+        creditCommandService.grantReferralSignupRewards(
+                new GrantReferralSignupRewardCommand(newUserId, referrerUserId)
+        );
+
+        // then: 새 유저 5000 크레딧으로 생성 검증
+        verify(creditRepository).save(argThat(credit ->
+                credit.getUserId().equals(newUserId) &&
+                credit.getBalance().equals(CreditCommandService.NEW_USER_REFERRAL_REWARD)
+        ));
+    }
+
+    @Test
+    @DisplayName("추천인 코드로 가입 시 추천인은 1000 크레딧을 받는다")
+    void referrer_receives_1000_credits_when_their_code_is_used() {
+        // given
+        Long newUserId = 10L;
+        Long referrerUserId = 1L;
+        Long referrerInitialBalance = 3000L;
+
+        when(creditRepository.findByUserId(newUserId)).thenReturn(Optional.empty());
+        Credit referrerCredit = Credit.create(referrerUserId, referrerInitialBalance);
+        when(creditRepository.findByUserIdForUpdate(referrerUserId))
+                .thenReturn(Optional.of(referrerCredit));
+        when(creditRepository.save(any())).thenAnswer(inv -> inv.getArgument(0));
+
+        // when
+        creditCommandService.grantReferralSignupRewards(
+                new GrantReferralSignupRewardCommand(newUserId, referrerUserId)
+        );
+
+        // then: 추천인 잔액 = 3000 + 1000 = 4000
+        assertThat(referrerCredit.getBalance())
+                .isEqualTo(referrerInitialBalance + CreditCommandService.REFERRER_REWARD);
+    }
+
+    @Test
+    @DisplayName("현재 지급 금액 확인: 새 유저 5000, 추천인 1000")
+    void verify_current_reward_amounts() {
+        assertThat(CreditCommandService.NEW_USER_REFERRAL_REWARD).isEqualTo(5000L);
+        assertThat(CreditCommandService.REFERRER_REWARD).isEqualTo(1000L);
+    }
+}

--- a/src/test/java/com/sashimi/user/application/service/UserWithdrawalFinalizationServiceTest.java
+++ b/src/test/java/com/sashimi/user/application/service/UserWithdrawalFinalizationServiceTest.java
@@ -1,0 +1,122 @@
+package com.sashimi.user.application.service;
+
+import com.sashimi.user.application.event.UserWithdrawnEvent;
+import com.sashimi.user.domain.model.Role;
+import com.sashimi.user.domain.model.User;
+import com.sashimi.user.domain.model.UserStatus;
+import com.sashimi.user.domain.repository.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
+
+@DisplayName("탈퇴 최종 처리 테스트")
+class UserWithdrawalFinalizationServiceTest {
+
+    private UserRepository userRepository;
+    private PasswordEncoder passwordEncoder;
+    private ApplicationEventPublisher eventPublisher;
+    private UserWithdrawalFinalizationService service;
+
+    @BeforeEach
+    void setUp() {
+        userRepository = mock(UserRepository.class);
+        passwordEncoder = mock(PasswordEncoder.class);
+        eventPublisher = mock(ApplicationEventPublisher.class);
+        service = new UserWithdrawalFinalizationService(userRepository, passwordEncoder, eventPublisher);
+
+        when(passwordEncoder.encode(any())).thenReturn("hashed-random-password");
+    }
+
+    @Test
+    @DisplayName("탈퇴 후 1년이 지난 유저는 개인정보가 익명화된다")
+    void user_data_is_anonymized_after_one_year_from_withdrawal() {
+        // given: 1년 전에 탈퇴한 유저
+        User inactiveUser = userDeactivatedYearsAgo(1, 1L);
+        when(userRepository.findAllByStatusAndDeactivatedAtBefore(any(), any()))
+                .thenReturn(List.of(inactiveUser));
+        when(userRepository.save(any())).thenAnswer(inv -> inv.getArgument(0));
+
+        // when
+        service.finalizeExpiredWithdrawals();
+
+        // then: 개인정보 익명화 확인
+        assertThat(inactiveUser.getStatus()).isEqualTo(UserStatus.DELETED);
+        assertThat(inactiveUser.getLoginId()).isEqualTo("d1");
+        assertThat(inactiveUser.getEmail()).isEqualTo("deleted_1@deleted.local");
+        assertThat(inactiveUser.getName()).isEqualTo("탈퇴회원");
+    }
+
+    @Test
+    @DisplayName("탈퇴 후 1년이 지난 유저는 UserWithdrawnEvent가 발행된다")
+    void withdrawn_event_is_published_after_one_year() {
+        // given
+        User inactiveUser = userDeactivatedYearsAgo(1, 2L);
+        when(userRepository.findAllByStatusAndDeactivatedAtBefore(any(), any()))
+                .thenReturn(List.of(inactiveUser));
+        when(userRepository.save(any())).thenReturn(inactiveUser);
+
+        // when
+        service.finalizeExpiredWithdrawals();
+
+        // then: 이벤트 발행 확인
+        ArgumentCaptor<UserWithdrawnEvent> captor = ArgumentCaptor.forClass(UserWithdrawnEvent.class);
+        verify(eventPublisher).publishEvent(captor.capture());
+        assertThat(captor.getValue().userId()).isEqualTo(2L);
+    }
+
+    @Test
+    @DisplayName("탈퇴 후 1년이 지나지 않은 유저는 처리되지 않는다")
+    void user_within_grace_period_is_not_processed() {
+        // given: 아직 1년이 안 된 유저는 조회 결과에 포함되지 않음
+        when(userRepository.findAllByStatusAndDeactivatedAtBefore(any(), any()))
+                .thenReturn(List.of());
+
+        // when
+        service.finalizeExpiredWithdrawals();
+
+        // then: 아무것도 처리되지 않음
+        verify(userRepository, never()).save(any());
+        verify(eventPublisher, never()).publishEvent(any(Object.class));
+    }
+
+    @Test
+    @DisplayName("여러 유저가 동시에 만료되면 모두 처리된다")
+    void multiple_expired_users_are_all_processed() {
+        // given
+        User user1 = userDeactivatedYearsAgo(1, 3L);
+        User user2 = userDeactivatedYearsAgo(2, 4L);
+        when(userRepository.findAllByStatusAndDeactivatedAtBefore(any(), any()))
+                .thenReturn(List.of(user1, user2));
+        when(userRepository.save(any())).thenAnswer(inv -> inv.getArgument(0));
+
+        // when
+        service.finalizeExpiredWithdrawals();
+
+        // then: 둘 다 처리됨
+        verify(userRepository, times(2)).save(any());
+        verify(eventPublisher, times(2)).publishEvent(any(Object.class));
+        assertThat(user1.getStatus()).isEqualTo(UserStatus.DELETED);
+        assertThat(user2.getStatus()).isEqualTo(UserStatus.DELETED);
+    }
+
+    private User userDeactivatedYearsAgo(int years, Long id) {
+        return new User(
+                id, "테스트유저", "testuser" + id, "password",
+                "test" + id + "@test.com", "010-0000-0000",
+                LocalDate.of(1990, 1, 1),
+                Role.STUDENT, UserStatus.INACTIVE, true,
+                "REF00" + id, List.of(),
+                LocalDateTime.now().minusYears(years).minusDays(1)
+        );
+    }
+}

--- a/src/test/java/com/sashimi/user/domain/repository/InMemoryUserRepositoryContractTest.java
+++ b/src/test/java/com/sashimi/user/domain/repository/InMemoryUserRepositoryContractTest.java
@@ -1,0 +1,13 @@
+package com.sashimi.user.domain.repository;
+
+import com.sashimi.user.infrastructure.persistence.InMemoryUserRepository;
+import org.junit.jupiter.api.DisplayName;
+
+@DisplayName("[계약 테스트] InMemoryUserRepository")
+class InMemoryUserRepositoryContractTest extends UserRepositoryContractTest {
+
+    @Override
+    protected UserRepository createRepository() {
+        return new InMemoryUserRepository();
+    }
+}

--- a/src/test/java/com/sashimi/user/domain/repository/UserRepositoryContractTest.java
+++ b/src/test/java/com/sashimi/user/domain/repository/UserRepositoryContractTest.java
@@ -1,0 +1,135 @@
+package com.sashimi.user.domain.repository;
+
+import com.sashimi.user.domain.model.User;
+import com.sashimi.user.domain.model.UserStatus;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * UserRepository 계약 테스트.
+ * 이 테스트를 상속하는 구현체는 모두 동일한 동작을 보장해야 한다.
+ */
+public abstract class UserRepositoryContractTest {
+
+    protected UserRepository userRepository;
+
+    // 각 구현체(InMemory, JPA)를 주입하는 메서드 - 하위 클래스에서 구현
+    protected abstract UserRepository createRepository();
+
+    @BeforeEach
+    void setUp() {
+        userRepository = createRepository();
+    }
+
+    private User sampleUser(String loginId, String email) {
+        return User.createStudent(
+                "테스트유저", loginId, "password123",
+                email, "010-0000-0000",
+                LocalDate.of(2000, 1, 1),
+                "REF001", List.of()
+        );
+    }
+
+    @Test
+    @DisplayName("저장한 유저를 ID로 조회할 수 있다")
+    void save_and_findById() {
+        User saved = userRepository.save(sampleUser("user1", "user1@test.com"));
+
+        Optional<User> found = userRepository.findById(saved.getId());
+
+        assertThat(found).isPresent();
+        assertThat(found.get().getLoginId()).isEqualTo("user1");
+    }
+
+    @Test
+    @DisplayName("저장한 유저를 loginId로 조회할 수 있다")
+    void findByLoginId() {
+        userRepository.save(sampleUser("user2", "user2@test.com"));
+
+        Optional<User> found = userRepository.findByLoginId("user2");
+
+        assertThat(found).isPresent();
+        assertThat(found.get().getEmail()).isEqualTo("user2@test.com");
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 loginId 조회 시 빈 Optional을 반환한다")
+    void findByLoginId_notFound() {
+        Optional<User> found = userRepository.findByLoginId("없는유저");
+
+        assertThat(found).isEmpty();
+    }
+
+    @Test
+    @DisplayName("저장한 유저를 email로 조회할 수 있다")
+    void findByEmail() {
+        userRepository.save(sampleUser("user3", "user3@test.com"));
+
+        Optional<User> found = userRepository.findByEmail("user3@test.com");
+
+        assertThat(found).isPresent();
+        assertThat(found.get().getLoginId()).isEqualTo("user3");
+    }
+
+    @Test
+    @DisplayName("loginId 중복 여부를 확인할 수 있다")
+    void existsByLoginId() {
+        userRepository.save(sampleUser("user4", "user4@test.com"));
+
+        assertThat(userRepository.existsByLoginId("user4")).isTrue();
+        assertThat(userRepository.existsByLoginId("없는유저")).isFalse();
+    }
+
+    @Test
+    @DisplayName("email 중복 여부를 확인할 수 있다")
+    void existsByEmail() {
+        userRepository.save(sampleUser("user5", "user5@test.com"));
+
+        assertThat(userRepository.existsByEmail("user5@test.com")).isTrue();
+        assertThat(userRepository.existsByEmail("없는@test.com")).isFalse();
+    }
+
+    @Test
+    @DisplayName("저장 시 ID가 자동 부여된다")
+    void save_assignsId() {
+        User saved = userRepository.save(sampleUser("user6", "user6@test.com"));
+
+        assertThat(saved.getId()).isNotNull();
+    }
+
+    @Test
+    @DisplayName("유저 정보를 수정 후 저장하면 반영된다")
+    void save_updatesExistingUser() {
+        User saved = userRepository.save(sampleUser("user7", "user7@test.com"));
+        saved.updateProfile("수정된이름", "new@test.com");
+        userRepository.save(saved);
+
+        User found = userRepository.findById(saved.getId()).orElseThrow();
+        assertThat(found.getName()).isEqualTo("수정된이름");
+        assertThat(found.getEmail()).isEqualTo("new@test.com");
+    }
+
+    @Test
+    @DisplayName("비활성화되고 특정 시간 이전에 탈퇴한 유저 목록을 조회할 수 있다")
+    void findAllByStatusAndDeactivatedAtBefore() {
+        User user = userRepository.save(sampleUser("user8", "user8@test.com"));
+        user.deactivate();
+        userRepository.save(user);
+
+        List<User> result = userRepository.findAllByStatusAndDeactivatedAtBefore(
+                UserStatus.INACTIVE,
+                LocalDateTime.now().plusSeconds(1)
+        );
+
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).getLoginId()).isEqualTo("user8");
+    }
+}

--- a/src/test/java/com/sashimi/user/infrastructure/persistence/InMemoryUserRepository.java
+++ b/src/test/java/com/sashimi/user/infrastructure/persistence/InMemoryUserRepository.java
@@ -1,0 +1,83 @@
+package com.sashimi.user.infrastructure.persistence;
+
+import com.sashimi.user.domain.model.User;
+import com.sashimi.user.domain.model.UserStatus;
+import com.sashimi.user.domain.repository.UserRepository;
+
+import java.time.LocalDateTime;
+import java.util.*;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.stream.Collectors;
+
+public class InMemoryUserRepository implements UserRepository {
+
+    private final Map<Long, User> store = new HashMap<>();
+    private final AtomicLong sequence = new AtomicLong(1);
+
+    @Override
+    public User save(User user) {
+        if (user.getId() == null) {
+            User saved = new User(
+                    sequence.getAndIncrement(),
+                    user.getName(), user.getLoginId(), user.getPassword(),
+                    user.getEmail(), user.getPhone(), user.getBirthDate(),
+                    user.getRole(), user.getStatus(), user.isEmailVerified(),
+                    user.getReferralCode(), user.getInterestCategoryIds(),
+                    user.getDeactivatedAt()
+            );
+            store.put(saved.getId(), saved);
+            return saved;
+        }
+        store.put(user.getId(), user);
+        return user;
+    }
+
+    @Override
+    public Optional<User> findById(Long id) {
+        return Optional.ofNullable(store.get(id));
+    }
+
+    @Override
+    public Optional<User> findByLoginId(String loginId) {
+        return store.values().stream()
+                .filter(u -> u.getLoginId().equals(loginId))
+                .findFirst();
+    }
+
+    @Override
+    public Optional<User> findByEmail(String email) {
+        return store.values().stream()
+                .filter(u -> u.getEmail().equals(email))
+                .findFirst();
+    }
+
+    @Override
+    public Optional<User> findByReferralCode(String referralCode) {
+        return store.values().stream()
+                .filter(u -> referralCode.equals(u.getReferralCode()))
+                .findFirst();
+    }
+
+    @Override
+    public boolean existsByLoginId(String loginId) {
+        return store.values().stream().anyMatch(u -> u.getLoginId().equals(loginId));
+    }
+
+    @Override
+    public boolean existsByEmail(String email) {
+        return store.values().stream().anyMatch(u -> u.getEmail().equals(email));
+    }
+
+    @Override
+    public boolean existsByReferralCode(String referralCode) {
+        return store.values().stream().anyMatch(u -> referralCode.equals(u.getReferralCode()));
+    }
+
+    @Override
+    public List<User> findAllByStatusAndDeactivatedAtBefore(UserStatus status, LocalDateTime dateTime) {
+        return store.values().stream()
+                .filter(u -> u.getStatus() == status)
+                .filter(u -> u.getDeactivatedAt() != null && u.getDeactivatedAt().isBefore(dateTime))
+                .collect(Collectors.toList());
+    }
+}


### PR DESCRIPTION
## 📌 PR 요약
- 아키텍처 테스트 도입 - ArchUnit + Port 계약 테스트

---

## 🛠️ 작업 상세 내용 (체크로 선택)
- [ ] ✨ FEATURE
- [x] 🔧 UPDATE
- [ ] 🐛 BUGFIX
- [ ] ♻️ REFACTOR
- [ ] 📝 DOCS

---

## 📋 작업 상세 내용
-   - ArchUnit으로 계층 의존성 규칙 위반을 CI에서 자동 감지                                                                                                                                                                           
  - Port 계약 테스트로 저장소 교체 가능성을 코드로 증명                                                                                                                                                                             
  - 추천인 크레딧, 탈퇴 처리 핵심 비즈니스 로직 테스트 추가
- 
- 

---

## 🔗 PR 관련 이슈로 닫기
Closes #150 

---

## ✅ 체크리스트 (확인 절차)
- [x] 정상적으로 빌드 및 실행됩니다.
- [x] 주요 기능이 정상 동작합니다.
- [ ] 불필요한 코드를 제거했습니다.
- [x] 코드 리뷰 준비가 완료되었습니다.

---

## 💬 리뷰어에게 할 말
-  1. 로컬 실행 필수 조건 변경                                                                                                                                                                                                       
  Redis가 없어도 앱이 동작하지만, 로그아웃 후 토큰 블랙리스트 기능이 비활성화됩니다. 로컬에 Redis 설치를 권장합니다.                                                                                                                
  winget install Redis.Redis                                                                                                                                                                                                        
                                                                                                                                                                                                                                    
  2. Flyway 초기 세팅 필요 (최초 1회)                                                                                                                                                                                               
  기존에 spring.sql.init으로 DB를 사용하던 경우, DB를 초기화해야 합니다.                                                                                                                                                            
  DROP DATABASE sixsashimi_db;                                                                                                                                                                                                      
  CREATE DATABASE sixsashimi_db DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;                                                                                                                                           
  이후 local 프로필로 앱 실행하면 V1~V6 자동 적용됩니다.                                                                                                                                                                            
                                                                                                                                                                                                                                    
  3. IntelliJ 실행 시 Active Profiles 설정 필요                                                                                                                                                                                     
  Run Configuration → Active Profiles에 local 입력 후 실행해야 합니다.                                                                                                                                                              
                                                                                                                                                                                                                                    
  4. 향후 DB 변경 규칙                                                                                                                                                                                                              
  schema.sql, data.sql, 기존 마이그레이션 파일은 절대 수정 금지. 변경 사항은 반드시 새 버전(V7__...sql)으로 추가해야 합니다.                                                                                                        
                                                                                                                                                                                                                                    
  5. JWT 변경 영향                                                                                                                                                                                                                  
  기존에 발급된 토큰에는 role 클레임이 없습니다. 프론트엔드 연동 시 재로그인이 필요합니다.

---