### PR TITLE
[UPDATE] #155 회원가입 환영 이메일 발송 - UserRegisteredEvent

### DIFF
--- a/src/main/java/com/sashimi/auth/service/AuthService.java
+++ b/src/main/java/com/sashimi/auth/service/AuthService.java
@@ -19,6 +19,7 @@ import com.sashimi.security.jwt.JwtTokenProvider;
 import com.sashimi.token.entity.RefreshToken;
 import com.sashimi.token.service.RefreshService;
 import com.sashimi.user.application.event.UserPasswordChangedEvent;
+import com.sashimi.user.application.event.UserRegisteredEvent;
 import com.sashimi.user.domain.model.User;
 import com.sashimi.user.domain.repository.UserRepository;
 import com.sashimi.user.dto.LoginIdCheckResponseDto;
@@ -95,6 +96,10 @@ public class AuthService {
                     new CreateInitialCreditCommand(savedUser.getId(), 0L)
             );
         }
+
+        eventPublisher.publishEvent(
+                new UserRegisteredEvent(savedUser.getId(), savedUser.getName(), savedUser.getEmail())
+        );
 
         return UserResponseDto.from(savedUser);
     }

--- a/src/main/java/com/sashimi/user/application/event/UserRegisteredEvent.java
+++ b/src/main/java/com/sashimi/user/application/event/UserRegisteredEvent.java
@@ -1,0 +1,8 @@
+package com.sashimi.user.application.event;
+
+public record UserRegisteredEvent(
+        Long userId,
+        String name,
+        String email
+) {
+}

--- a/src/main/java/com/sashimi/user/application/event/UserRegisteredWelcomeEmailHandler.java
+++ b/src/main/java/com/sashimi/user/application/event/UserRegisteredWelcomeEmailHandler.java
@@ -1,0 +1,32 @@
+package com.sashimi.user.application.event;
+
+import com.sashimi.verification.application.port.EmailSender;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class UserRegisteredWelcomeEmailHandler {
+
+    private final EmailSender emailSender;
+
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void handle(UserRegisteredEvent event) {
+        emailSender.send(
+                event.email(),
+                "[Sashimi Six] 가입을 환영합니다!",
+                createContent(event.name())
+        );
+
+        log.info("환영 이메일 발송 완료. userId={}, email={}", event.userId(), event.email());
+    }
+
+    private String createContent(String name) {
+        return name + "님, Sashimi Six에 오신 걸 환영합니다!\n"
+                + "다양한 강의를 통해 새로운 것을 배워보세요.";
+    }
+}


### PR DESCRIPTION
## 📌 PR 요약
-  회원가입 성공 시 신규 유저에게 환영 이메일을 자동 발송하는 기능을 추가했습니다.                                                                                     
  기존 UserPasswordChangedSecurityNotificationHandler와 동일한 도메인 이벤트 패턴으로 구현했습니다.

---

## 🛠️ 작업 상세 내용 (체크로 선택)
- [ ] ✨ FEATURE
- [ ] 🔧 UPDATE
- [ ] 🐛 BUGFIX
- [ ] ♻️ REFACTOR
- [ ] 📝 DOCS

---

## 📋 작업 상세 내용
- - UserRegisteredEvent 생성 — userId, name, email 포함                                                                                                               
  - UserRegisteredWelcomeEmailHandler 생성 — @TransactionalEventListener(AFTER_COMMIT) 로 환영 메일 발송                                                              
  - AuthService.register() 완료 후 UserRegisteredEvent 발행
- 
- 

---

## 🔗 PR 관련 이슈로 닫기
Closes #155 

---

## ✅ 체크리스트 (확인 절차)
- [ ] 정상적으로 빌드 및 실행됩니다.
- [ ] 주요 기능이 정상 동작합니다.
- [ ] 불필요한 코드를 제거했습니다.
- [ ] 코드 리뷰 준비가 완료되었습니다.

---

## 💬 리뷰어에게 할 말
- @TransactionalEventListener(AFTER_COMMIT) 을 사용했기 때문에 메일 발송 실패가 회원가입 트랜잭션을 롤백시키지 않습니다. 회원가입은 무조건 성공하고 메일만 실패할 수  있습니다.
- 
<img width="1670" height="887" alt="image" src="https://github.com/user-attachments/assets/5d7e0e3c-b8cc-45f7-95fc-8683d4980787" />


---