### PR TITLE
[UPDATE] #000 장바구니 항목 다건 삭제 추가

### DIFF
--- a/src/main/java/com/sashimi/cart/application/command/DeleteCartItemCommand.java
+++ b/src/main/java/com/sashimi/cart/application/command/DeleteCartItemCommand.java
@@ -1,7 +1,9 @@
 package com.sashimi.cart.application.command;
 
+import java.util.List;
+
 public record DeleteCartItemCommand(
         Long userId,
-        Long cartItemId
+        List<Long> cartItemIds
 ) {
 }

--- a/src/main/java/com/sashimi/cart/application/service/CartCommandService.java
+++ b/src/main/java/com/sashimi/cart/application/service/CartCommandService.java
@@ -56,10 +56,24 @@ public class CartCommandService implements CartCommandUseCase {
 
     @Override
     public void deleteCartItem(DeleteCartItemCommand command) {
-        CartItem cartItem = cartItemRepository.findByIdAndUserId(command.cartItemId(), command.userId())
-                .orElseThrow(() -> new BusinessException(ErrorCode.CART_ITEM_NOT_FOUND));
+        if (command.userId() == null) {
+            throw new BusinessException(ErrorCode.INVALID_INPUT_VALUE);
+        }
 
-        cartItemRepository.delete(cartItem);
+        if (command.cartItemIds() == null || command.cartItemIds().isEmpty()) {
+            throw new BusinessException(ErrorCode.CART_INVALID_SELECTION);
+        }
+
+        for (Long cartItemId : command.cartItemIds()) {
+            if (cartItemId == null) {
+                throw new BusinessException(ErrorCode.CART_INVALID_SELECTION);
+            }
+
+            CartItem cartItem = cartItemRepository.findByIdAndUserId(cartItemId, command.userId())
+                    .orElseThrow(() -> new BusinessException(ErrorCode.CART_ITEM_NOT_FOUND));
+
+            cartItemRepository.delete(cartItem);
+        }
     }
 
     @Override

--- a/src/main/java/com/sashimi/cart/presentation/api/CartController.java
+++ b/src/main/java/com/sashimi/cart/presentation/api/CartController.java
@@ -7,10 +7,12 @@ import com.sashimi.cart.application.command.UpdateCartItemsSelectionCommand;
 import com.sashimi.cart.application.usecase.CartCommandUseCase;
 import com.sashimi.cart.application.usecase.CartQueryUseCase;
 import com.sashimi.cart.presentation.api.request.AddCartItemRequest;
+import com.sashimi.cart.presentation.api.request.DeleteCartItemsRequest;
 import com.sashimi.cart.presentation.api.request.UpdateCartItemSelectionRequest;
 import com.sashimi.cart.presentation.api.request.UpdateCartItemsSelectionRequest;
 import com.sashimi.cart.presentation.api.response.AddCartItemResponse;
 import com.sashimi.cart.presentation.api.response.CartResponse;
+import com.sashimi.global.exception.ErrorResponse;
 import com.sashimi.security.principal.CustomUserPrincipal;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -23,7 +25,7 @@ import jakarta.validation.Valid;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.ErrorResponse;
+
 import org.springframework.web.bind.annotation.*;
 
 @Tag(name = "Cart", description = "장바구니 API")
@@ -93,19 +95,35 @@ public class CartController {
                 .body(new AddCartItemResponse(request.courseId(), cartItemId));
     }
 
-    @Operation(summary = "장바구니 항목 삭제", description = "장바구니 항목 ID로 특정 항목을 삭제합니다.")
+    @Operation(summary = "장바구니 항목 삭제", description = "장바구니 항목 ID 목록으로 단건 또는 다건 항목을 삭제합니다.")
     @ApiResponses({
-            @ApiResponse(responseCode = "204", description = "장바구니 항목 삭제 성공"),
-            @ApiResponse(responseCode = "401", description = "인증 실패"),
-            @ApiResponse(responseCode = "404", description = "장바구니 항목을 찾을 수 없음")
+            @ApiResponse(
+                    responseCode = "204",
+                    description = "장바구니 항목 삭제 성공"
+            ),
+            @ApiResponse(
+                    responseCode = "400",
+                    description = "잘못된 삭제 요청",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+            ),
+            @ApiResponse(
+                    responseCode = "401",
+                    description = "인증 실패",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+            ),
+            @ApiResponse(
+                    responseCode = "404",
+                    description = "장바구니 항목을 찾을 수 없음",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+            )
     })
-    @DeleteMapping("/{cartItemId}")
+    @DeleteMapping
     public ResponseEntity<Void> deleteCartItem(
             @AuthenticationPrincipal CustomUserPrincipal principal,
-            @PathVariable Long cartItemId
+            @RequestBody @Valid DeleteCartItemsRequest request
     ) {
         cartCommandUseCase.deleteCartItem(
-                new DeleteCartItemCommand(principal.getId(), cartItemId)
+                new DeleteCartItemCommand(principal.getId(), request.cartItemIds())
         );
 
         return ResponseEntity.noContent().build();

--- a/src/main/java/com/sashimi/cart/presentation/api/request.http
+++ b/src/main/java/com/sashimi/cart/presentation/api/request.http
@@ -37,10 +37,25 @@ Authorization: Bearer {{accessToken}}
   "selected": true
 }
 
-### 장바구니 항목 삭제
-DELETE {{baseUrl}}/cart/1
+### 장바구니 항목 삭제 - 단건
+DELETE {{baseUrl}}/cart
+Content-Type: application/json
 Accept: application/json
 Authorization: Bearer {{accessToken}}
+
+{
+  "cartItemIds": [1]
+}
+
+### 장바구니 항목 삭제 - 다건
+DELETE {{baseUrl}}/cart
+Content-Type: application/json
+Accept: application/json
+Authorization: Bearer {{accessToken}}
+
+{
+  "cartItemIds": [1, 2, 3]
+}
 
 ### 장바구니 결제 전 조회
 POST {{baseUrl}}/cart/checkout

--- a/src/main/java/com/sashimi/cart/presentation/api/request/DeleteCartItemsRequest.java
+++ b/src/main/java/com/sashimi/cart/presentation/api/request/DeleteCartItemsRequest.java
@@ -1,0 +1,8 @@
+package com.sashimi.cart.presentation.api.request;
+
+import java.util.List;
+
+public record DeleteCartItemsRequest(
+        List<Long> cartItemIds
+) {
+}

--- a/src/main/java/com/sashimi/payment/presentation/api/PaymentController.java
+++ b/src/main/java/com/sashimi/payment/presentation/api/PaymentController.java
@@ -1,5 +1,6 @@
 package com.sashimi.payment.presentation.api;
 
+import com.sashimi.global.exception.ErrorResponse;
 import com.sashimi.payment.application.command.CheckoutCartCommand;
 import com.sashimi.payment.application.command.PayCourseCommand;
 import com.sashimi.payment.application.usecase.PaymentCommandUseCase;
@@ -17,7 +18,6 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.ErrorResponse;
 import org.springframework.web.bind.annotation.*;
 
 @Tag(name = "Payment", description = "결제 API")


### PR DESCRIPTION
## 📌 PR 요약
- 장바구니 항목 삭제 시 단건 삭제 밖에 없어 여러 항목 삭제할 때 프론트 측에서 계속 한개씩 응답을 계속 보내야 해서
장바구니 다건 삭제 추가 진행 

---

## 🛠️ 작업 상세 내용 (체크로 선택)
- [ ] ✨ FEATURE
- [x] 🔧 UPDATE
- [ ] 🐛 BUGFIX
- [ ] ♻️ REFACTOR
- [ ] 📝 DOCS

---

## 📋 작업 상세 내용
- 
- 
- 

---

## 🔗 PR 관련 이슈로 닫기
Closes #

---

## ✅ 체크리스트 (확인 절차)
- [x] 정상적으로 빌드 및 실행됩니다.
- [x] 주요 기능이 정상 동작합니다.
- [ ] 불필요한 코드를 제거했습니다.
- [ ] 코드 리뷰 준비가 완료되었습니다.

---

## 💬 리뷰어에게 할 말
- 

---