### PR TITLE
[UPDATE] 만료 Refresh Token 자동 정리 + Refresh Token 감사/추적 컬럼 추가 + 로그인 동시 접속 제한 구현 + 한글깨짐 수정 

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,3 @@
+# yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
+language: "ko-KR"
+tone_instructions: "Always write responses, review summaries, and comments in Korean."

--- a/src/main/java/com/sashimi/course/domain/model/Course.java
+++ b/src/main/java/com/sashimi/course/domain/model/Course.java
@@ -84,7 +84,7 @@ public class Course {
     public Course update(Long categoryId, Long ncsInfoId, String title, String description, Long price,
                          CourseDifficulty difficulty, String thumbnail, CourseStatus targetStatus,
                          List<CourseSession> sessions) {
-        if (!canModify()) throw new IllegalStateException("?섏젙?????녿뒗 ?곹깭??媛뺤쓽?낅땲??");
+        if (!canModify()) throw new IllegalStateException("수정할 수 없는 상태의 강의입니다.");
         validateWritableStatus(targetStatus);
         int totalDuration = sessions == null ? 0 : sessions.stream().mapToInt(CourseSession::getDurationSeconds).sum();
         return new Course(this.id, this.instructorId, categoryId, ncsInfoId, title, description,
@@ -94,7 +94,7 @@ public class Course {
     }
 
     public Course approve() {
-        if (this.status != CourseStatus.PENDING) throw new IllegalStateException("?뱀씤 ?湲??곹깭媛 ?꾨땶 媛뺤쓽?낅땲??");
+        if (this.status != CourseStatus.PENDING) throw new IllegalStateException("승인 대기 상태가 아닌 강의입니다.");
         return new Course(id, instructorId, categoryId, ncsInfoId, title, description, price,
                 difficulty, thumbnail, totalDuration, CourseStatus.APPROVED, null,
                 ratingAvg, reviewCount, studentCount, createdAt, LocalDateTime.now(),
@@ -102,7 +102,7 @@ public class Course {
     }
 
     public Course reject(String reason) {
-        if (this.status != CourseStatus.PENDING) throw new IllegalStateException("?뱀씤 ?湲??곹깭媛 ?꾨땶 媛뺤쓽?낅땲??");
+        if (this.status != CourseStatus.PENDING) throw new IllegalStateException("승인 대기 상태가 아닌 강의입니다.");
         return new Course(id, instructorId, categoryId, ncsInfoId, title, description, price,
                 difficulty, thumbnail, totalDuration, CourseStatus.REJECTED, reason,
                 ratingAvg, reviewCount, studentCount, createdAt, LocalDateTime.now(),

--- a/src/main/java/com/sashimi/token/entity/RefreshToken.java
+++ b/src/main/java/com/sashimi/token/entity/RefreshToken.java
@@ -24,21 +24,59 @@ public class RefreshToken {
     @Column(nullable = false, unique = true, length = 512)
     private String token;
 
+    @Column(name = "issued_at", nullable = false)
+    private LocalDateTime issuedAt;
+
+    @Column(name = "last_used_at")
+    private LocalDateTime lastUsedAt;
+
     @Column(name = "expiry_date", nullable = false)
     private LocalDateTime expiryDate;
 
+    @Column(name = "revoked_at")
+    private LocalDateTime revokedAt;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "revoked_reason", length = 50)
+    private RefreshTokenRevokedReason revokedReason;
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
     public RefreshToken(Long userId, String token, LocalDateTime expiryDate) {
+        LocalDateTime now = LocalDateTime.now();
         this.userId = userId;
         this.token = token;
         this.expiryDate = expiryDate;
+        this.issuedAt = now;
+        this.lastUsedAt = now;
+        this.createdAt = now;
     }
 
     public boolean isExpired() {
         return LocalDateTime.now().isAfter(expiryDate);
     }
 
+    public boolean isRevoked() {
+        return revokedAt != null;
+    }
+
     public void updateToken(String token, LocalDateTime expiryDate) {
+        LocalDateTime now = LocalDateTime.now();
         this.token = token;
         this.expiryDate = expiryDate;
+        this.issuedAt = now;
+        this.lastUsedAt = now;
+        this.revokedAt = null;
+        this.revokedReason = null;
+    }
+
+    public void markUsed(LocalDateTime usedAt) {
+        this.lastUsedAt = usedAt;
+    }
+
+    public void revoke(RefreshTokenRevokedReason reason, LocalDateTime revokedAt) {
+        this.revokedAt = revokedAt;
+        this.revokedReason = reason;
     }
 }

--- a/src/main/java/com/sashimi/token/entity/RefreshTokenRevokedReason.java
+++ b/src/main/java/com/sashimi/token/entity/RefreshTokenRevokedReason.java
@@ -1,0 +1,9 @@
+package com.sashimi.token.entity;
+
+public enum RefreshTokenRevokedReason {
+    LOGOUT,
+    PASSWORD_CHANGED,
+    WITHDRAWAL,
+    EXPIRED,
+    ADMIN_REVOKED
+}

--- a/src/main/java/com/sashimi/token/repository/RefreshTokenRepository.java
+++ b/src/main/java/com/sashimi/token/repository/RefreshTokenRepository.java
@@ -3,6 +3,7 @@ package com.sashimi.token.repository;
 import com.sashimi.token.entity.RefreshToken;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.time.LocalDateTime;
 import java.util.Optional;
 
 public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long> {
@@ -12,4 +13,6 @@ public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long
     Optional<RefreshToken> findByUserId(Long userId);
 
     void deleteByUserId(Long userId);
+
+    void deleteByExpiryDateBefore(LocalDateTime dateTime);
 }

--- a/src/main/java/com/sashimi/token/scheduler/RefreshTokenCleanupScheduler.java
+++ b/src/main/java/com/sashimi/token/scheduler/RefreshTokenCleanupScheduler.java
@@ -1,0 +1,22 @@
+package com.sashimi.token.scheduler;
+
+import com.sashimi.token.service.RefreshService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class RefreshTokenCleanupScheduler {
+
+    private final RefreshService refreshService;
+
+    @Scheduled(cron = "0 0 3 * * *")
+    public void deleteExpiredTokens() {
+        log.info("[RefreshTokenCleanup] 만료된 refresh token 정리 시작");
+        refreshService.deleteExpiredTokens();
+        log.info("[RefreshTokenCleanup] 만료된 refresh token 정리 완료");
+    }
+}

--- a/src/main/java/com/sashimi/token/service/RefreshService.java
+++ b/src/main/java/com/sashimi/token/service/RefreshService.java
@@ -44,4 +44,8 @@ public class RefreshService {
     public void deleteByUser(User user) {
         refreshTokenRepository.deleteByUserId(user.getId());
     }
+
+    public void deleteExpiredTokens() {
+        refreshTokenRepository.deleteByExpiryDateBefore(LocalDateTime.now());
+    }
 }

--- a/src/main/resources/db/migration/V2.7__add_refresh_token_audit_columns.sql
+++ b/src/main/resources/db/migration/V2.7__add_refresh_token_audit_columns.sql
@@ -1,0 +1,5 @@
+ALTER TABLE refresh_tokens
+    ADD COLUMN issued_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP AFTER token,
+    ADD COLUMN last_used_at DATETIME NULL AFTER issued_at,
+    ADD COLUMN revoked_at DATETIME NULL AFTER expiry_date,
+    ADD COLUMN revoked_reason VARCHAR(50) NULL AFTER revoked_at;


### PR DESCRIPTION
## 📌 PR 요약
- 만료 Refresh Token 자동 정리 + Refresh Token 감사/추적 컬럼 추가 + 로그인 동시 접속 제한 구현 + 한글깨짐 수정 

---

## 🛠️ 작업 상세 내용 (체크로 선택)
- [ ] ✨ FEATURE
- [ ] 🔧 UPDATE
- [ ] 🐛 BUGFIX
- [ ] ♻️ REFACTOR
- [ ] 📝 DOCS

---

## 📋 작업 상세 내용
- 만료 Refresh Token 자동 정리
RefreshTokenRepository.java
만료 시간이 지난 refresh token을 삭제하는 메서드 추가

RefreshService.java
만료된 refresh token을 정리하는 서비스 메서드 추가

RefreshTokenCleanupScheduler.java
매일 새벽 3시에 만료된 refresh token을 삭제하는 스케줄러 추가

Refresh Token 감사/추적 컬럼 추가
V2.7__add_refresh_token_audit_columns.sql
issued_at, last_used_at, revoked_at, revoked_reason 컬럼 추가

RefreshToken.java
감사/추적 필드 4개 추가
isRevoked(), markUsed(), revoke(), updateToken() 메서드 추가 또는 수정

RefreshTokenRevokedReason.java
refresh token 무효화 사유 enum 추가
- 
- 

---

## 🔗 PR 관련 이슈로 닫기
Closes #204 

---

## ✅ 체크리스트 (확인 절차)
- [ ] 정상적으로 빌드 및 실행됩니다.
- [ ] 주요 기능이 정상 동작합니다.
- [ ] 불필요한 코드를 제거했습니다.
- [ ] 코드 리뷰 준비가 완료되었습니다.

---

## 💬 리뷰어에게 할 말
- 

---

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * Refresh 토큰의 발급, 사용, 폐기 시각을 추적할 수 있도록 개선
  * 폐기된 Refresh 토큰의 폐기 사유를 기록하는 기능 추가
  * 만료된 Refresh 토큰을 매일 자동으로 정리하는 스케줄러 추가

* **개선 사항**
  * 오류 메시지를 한국어로 표시하도록 개선

db 마이그레이션 2.7 버전 진행했습니다~
<!-- end of auto-generated comment: release notes by coderabbit.ai -->