### PR TITLE
[UPDATE]  #217,218,191 module 3 수정+수강생 강의 기한 설정 기능+강의 비공개 상태 추가 및 강의 조회 api 전체 수정 

### DIFF
--- a/src/main/java/com/sashimi/course/application/service/CourseCommandService.java
+++ b/src/main/java/com/sashimi/course/application/service/CourseCommandService.java
@@ -5,6 +5,7 @@ import com.sashimi.course.application.port.CategoryPort;
 import com.sashimi.course.application.usecase.CourseCommandUseCase;
 import com.sashimi.course.domain.model.Course;
 import com.sashimi.course.domain.model.CourseSession;
+import com.sashimi.course.domain.model.CourseStatus;
 import com.sashimi.course.domain.repository.CourseRepository;
 import com.sashimi.global.exception.BusinessException;
 import com.sashimi.global.exception.ErrorCode;
@@ -12,12 +13,16 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 @Service
 @Transactional
 @RequiredArgsConstructor
 public class CourseCommandService implements CourseCommandUseCase {
+
+    /** 승인일(공개 시작) 기준 공개 기간 (년) */
+    private static final int PUBLICATION_PERIOD_YEARS = 2;
 
     private final CourseRepository courseRepository;
     private final CategoryPort categoryPort;
@@ -91,5 +96,14 @@ public class CourseCommandService implements CourseCommandUseCase {
                 .orElseThrow(() -> new BusinessException(ErrorCode.COURSE_NOT_FOUND));
 
         courseRepository.save(course.reject(command.rejectReason()));
+    }
+
+    @Override
+    public int closeExpiredCourses() {
+        LocalDateTime cutoff = LocalDateTime.now().minusYears(PUBLICATION_PERIOD_YEARS);
+        List<Course> expiredCourses = courseRepository.findByStatusAndApprovedAtBefore(
+                CourseStatus.APPROVED, cutoff);
+        expiredCourses.forEach(course -> courseRepository.save(course.close()));
+        return expiredCourses.size();
     }
 }

--- a/src/main/java/com/sashimi/course/application/service/CourseCommandService.java
+++ b/src/main/java/com/sashimi/course/application/service/CourseCommandService.java
@@ -8,6 +8,7 @@ import com.sashimi.course.domain.model.CourseSession;
 import com.sashimi.course.domain.repository.CourseRepository;
 import com.sashimi.global.exception.BusinessException;
 import com.sashimi.global.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -15,15 +16,11 @@ import java.util.List;
 
 @Service
 @Transactional
+@RequiredArgsConstructor
 public class CourseCommandService implements CourseCommandUseCase {
 
     private final CourseRepository courseRepository;
     private final CategoryPort categoryPort;
-
-    public CourseCommandService(CourseRepository courseRepository, CategoryPort categoryPort) {
-        this.courseRepository = courseRepository;
-        this.categoryPort = categoryPort;
-    }
 
     @Override
     public Long createCourse(CreateCourseCommand command) {
@@ -49,10 +46,6 @@ public class CourseCommandService implements CourseCommandUseCase {
 
         if (!course.getInstructorId().equals(command.instructorId())) {
             throw new BusinessException(ErrorCode.COURSE_FORBIDDEN);
-        }
-
-        if (!course.canModify()) {
-            throw new BusinessException(ErrorCode.COURSE_NOT_MODIFIABLE);
         }
 
         List<CourseSession> sessions = command.sessions().stream()

--- a/src/main/java/com/sashimi/course/application/service/CourseQueryService.java
+++ b/src/main/java/com/sashimi/course/application/service/CourseQueryService.java
@@ -6,6 +6,7 @@ import com.sashimi.course.domain.model.CourseStatus;
 import com.sashimi.course.domain.repository.CourseRepository;
 import com.sashimi.global.exception.BusinessException;
 import com.sashimi.global.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -13,13 +14,10 @@ import java.util.List;
 
 @Service
 @Transactional(readOnly = true)
+@RequiredArgsConstructor
 public class CourseQueryService implements CourseQueryUseCase {
 
     private final CourseRepository courseRepository;
-
-    public CourseQueryService(CourseRepository courseRepository) {
-        this.courseRepository = courseRepository;
-    }
 
     @Override
     public List<Course> getApprovedCoursesByInstructor(Long instructorId) {

--- a/src/main/java/com/sashimi/course/application/service/CourseQueryService.java
+++ b/src/main/java/com/sashimi/course/application/service/CourseQueryService.java
@@ -31,6 +31,11 @@ public class CourseQueryService implements CourseQueryUseCase {
     }
 
     @Override
+    public List<Course> getClosedCoursesByInstructor(Long instructorId) {
+        return courseRepository.findByInstructorIdAndStatus(instructorId, CourseStatus.CLOSED);
+    }
+
+    @Override
     public Course getCourseDetail(Long courseId, Long instructorId) {
         Course course = courseRepository.findById(courseId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.COURSE_NOT_FOUND));
@@ -43,8 +48,8 @@ public class CourseQueryService implements CourseQueryUseCase {
     }
 
     @Override
-    public List<Course> getApprovedCoursesForAdmin() {
-        return courseRepository.findByStatus(CourseStatus.APPROVED);
+    public List<Course> getAllCoursesForAdmin() {
+        return courseRepository.findByStatusIn(List.of(CourseStatus.APPROVED, CourseStatus.CLOSED));
     }
 
     @Override
@@ -55,5 +60,10 @@ public class CourseQueryService implements CourseQueryUseCase {
     @Override
     public List<Course> getRejectedCoursesForAdmin() {
         return courseRepository.findByStatus(CourseStatus.REJECTED);
+    }
+
+    @Override
+    public List<Course> getClosedCoursesForAdmin() {
+        return courseRepository.findByStatus(CourseStatus.CLOSED);
     }
 }

--- a/src/main/java/com/sashimi/course/application/service/PublicCourseQueryService.java
+++ b/src/main/java/com/sashimi/course/application/service/PublicCourseQueryService.java
@@ -10,6 +10,7 @@ import com.sashimi.course.domain.model.CourseStatus;
 import com.sashimi.course.domain.repository.CourseRepository;
 import com.sashimi.global.exception.BusinessException;
 import com.sashimi.global.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -21,19 +22,12 @@ import java.util.stream.Collectors;
 
 @Service
 @Transactional(readOnly = true)
+@RequiredArgsConstructor
 public class PublicCourseQueryService implements PublicCourseQueryUseCase {
 
     private final CourseRepository courseRepository;
     private final CategoryPort categoryPort;
     private final InstructorPort instructorPort;
-
-    public PublicCourseQueryService(CourseRepository courseRepository,
-                                    CategoryPort categoryPort,
-                                    InstructorPort instructorPort) {
-        this.courseRepository = courseRepository;
-        this.categoryPort = categoryPort;
-        this.instructorPort = instructorPort;
-    }
 
     @Override
     public List<PublicCourseView> getAllApprovedCourses() {

--- a/src/main/java/com/sashimi/course/application/usecase/CourseCommandUseCase.java
+++ b/src/main/java/com/sashimi/course/application/usecase/CourseCommandUseCase.java
@@ -12,4 +12,5 @@ public interface CourseCommandUseCase {
     void deleteCourse(DeleteCourseCommand command);
     void approveCourse(ApproveCourseCommand command);
     void rejectCourse(RejectCourseCommand command);
+    int closeExpiredCourses();
 }

--- a/src/main/java/com/sashimi/course/application/usecase/CourseQueryUseCase.java
+++ b/src/main/java/com/sashimi/course/application/usecase/CourseQueryUseCase.java
@@ -7,8 +7,10 @@ import java.util.List;
 public interface CourseQueryUseCase {
     List<Course> getApprovedCoursesByInstructor(Long instructorId);
     List<Course> getInProgressCoursesByInstructor(Long instructorId);
+    List<Course> getClosedCoursesByInstructor(Long instructorId);
     Course getCourseDetail(Long courseId, Long instructorId);
-    List<Course> getApprovedCoursesForAdmin();
+    List<Course> getAllCoursesForAdmin();
     List<Course> getPendingCoursesForAdmin();
     List<Course> getRejectedCoursesForAdmin();
+    List<Course> getClosedCoursesForAdmin();
 }

--- a/src/main/java/com/sashimi/course/domain/model/Course.java
+++ b/src/main/java/com/sashimi/course/domain/model/Course.java
@@ -1,5 +1,8 @@
 package com.sashimi.course.domain.model;
 
+import com.sashimi.global.exception.BusinessException;
+import com.sashimi.global.exception.ErrorCode;
+
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
 import java.util.List;
@@ -31,12 +34,12 @@ public class Course {
                    CourseStatus status, String rejectReason, BigDecimal ratingAvg,
                    int reviewCount, int studentCount, LocalDateTime createdAt,
                    LocalDateTime updatedAt, LocalDateTime approvedAt, List<CourseSession> sessions) {
-        if (instructorId == null) throw new IllegalArgumentException("Instructor id is required.");
-        if (categoryId == null) throw new IllegalArgumentException("Category id is required.");
-        if (title == null || title.isBlank()) throw new IllegalArgumentException("Title is required.");
-        if (price == null || price < 0) throw new IllegalArgumentException("Price must be zero or positive.");
-        if (difficulty == null) throw new IllegalArgumentException("Difficulty is required.");
-        if (status == null) throw new IllegalArgumentException("Status is required.");
+        if (instructorId == null) throw new BusinessException(ErrorCode.INVALID_INPUT_VALUE);
+        if (categoryId == null) throw new BusinessException(ErrorCode.INVALID_INPUT_VALUE);
+        if (title == null || title.isBlank()) throw new BusinessException(ErrorCode.INVALID_INPUT_VALUE);
+        if (price == null || price < 0) throw new BusinessException(ErrorCode.INVALID_INPUT_VALUE);
+        if (difficulty == null) throw new BusinessException(ErrorCode.INVALID_INPUT_VALUE);
+        if (status == null) throw new BusinessException(ErrorCode.INVALID_INPUT_VALUE);
 
         this.id = id;
         this.instructorId = instructorId;
@@ -84,7 +87,7 @@ public class Course {
     public Course update(Long categoryId, Long ncsInfoId, String title, String description, Long price,
                          CourseDifficulty difficulty, String thumbnail, CourseStatus targetStatus,
                          List<CourseSession> sessions) {
-        if (!canModify()) throw new IllegalStateException("수정할 수 없는 상태의 강의입니다.");
+        if (!canModify()) throw new BusinessException(ErrorCode.COURSE_NOT_MODIFIABLE);
         validateWritableStatus(targetStatus);
         int totalDuration = sessions == null ? 0 : sessions.stream().mapToInt(CourseSession::getDurationSeconds).sum();
         return new Course(this.id, this.instructorId, categoryId, ncsInfoId, title, description,
@@ -94,7 +97,7 @@ public class Course {
     }
 
     public Course approve() {
-        if (this.status != CourseStatus.PENDING) throw new IllegalStateException("승인 대기 상태가 아닌 강의입니다.");
+        if (this.status != CourseStatus.PENDING) throw new BusinessException(ErrorCode.COURSE_NOT_PENDING);
         return new Course(id, instructorId, categoryId, ncsInfoId, title, description, price,
                 difficulty, thumbnail, totalDuration, CourseStatus.APPROVED, null,
                 ratingAvg, reviewCount, studentCount, createdAt, LocalDateTime.now(),
@@ -102,7 +105,7 @@ public class Course {
     }
 
     public Course reject(String reason) {
-        if (this.status != CourseStatus.PENDING) throw new IllegalStateException("승인 대기 상태가 아닌 강의입니다.");
+        if (this.status != CourseStatus.PENDING) throw new BusinessException(ErrorCode.COURSE_NOT_PENDING);
         return new Course(id, instructorId, categoryId, ncsInfoId, title, description, price,
                 difficulty, thumbnail, totalDuration, CourseStatus.REJECTED, reason,
                 ratingAvg, reviewCount, studentCount, createdAt, LocalDateTime.now(),
@@ -111,7 +114,7 @@ public class Course {
 
     private static void validateWritableStatus(CourseStatus status) {
         if (status != CourseStatus.DRAFT && status != CourseStatus.PENDING) {
-            throw new IllegalArgumentException("Course status must be DRAFT or PENDING.");
+            throw new BusinessException(ErrorCode.INVALID_INPUT_VALUE);
         }
     }
 

--- a/src/main/java/com/sashimi/course/domain/model/Course.java
+++ b/src/main/java/com/sashimi/course/domain/model/Course.java
@@ -112,6 +112,15 @@ public class Course {
                 null, sessions);
     }
 
+    /** 승인 강의의 공개 기간 만료 시 비공개(CLOSED) 처리. 승인일은 보존한다. */
+    public Course close() {
+        if (this.status != CourseStatus.APPROVED) throw new BusinessException(ErrorCode.INVALID_INPUT_VALUE);
+        return new Course(id, instructorId, categoryId, ncsInfoId, title, description, price,
+                difficulty, thumbnail, totalDuration, CourseStatus.CLOSED, rejectReason,
+                ratingAvg, reviewCount, studentCount, createdAt, LocalDateTime.now(),
+                approvedAt, sessions);
+    }
+
     private static void validateWritableStatus(CourseStatus status) {
         if (status != CourseStatus.DRAFT && status != CourseStatus.PENDING) {
             throw new BusinessException(ErrorCode.INVALID_INPUT_VALUE);

--- a/src/main/java/com/sashimi/course/domain/model/CourseSession.java
+++ b/src/main/java/com/sashimi/course/domain/model/CourseSession.java
@@ -1,5 +1,8 @@
 package com.sashimi.course.domain.model;
 
+import com.sashimi.global.exception.BusinessException;
+import com.sashimi.global.exception.ErrorCode;
+
 import java.time.LocalDateTime;
 import java.util.UUID;
 
@@ -24,8 +27,8 @@ public class CourseSession {
                           int durationSeconds, int sessionOrder, boolean preview,
                           String attachmentName, String attachmentUrl, String attachmentType,
                           Long attachmentSize, LocalDateTime createdAt, LocalDateTime updatedAt) {
-        if (title == null || title.isBlank()) throw new IllegalArgumentException("Session title is required.");
-        if (sessionUid == null) throw new IllegalArgumentException("Session UID is required.");
+        if (title == null || title.isBlank()) throw new BusinessException(ErrorCode.INVALID_INPUT_VALUE);
+        if (sessionUid == null) throw new BusinessException(ErrorCode.INVALID_INPUT_VALUE);
         this.id = id;
         this.sessionUid = sessionUid;
         this.courseId = courseId;

--- a/src/main/java/com/sashimi/course/domain/repository/CourseRepository.java
+++ b/src/main/java/com/sashimi/course/domain/repository/CourseRepository.java
@@ -3,6 +3,7 @@ package com.sashimi.course.domain.repository;
 import com.sashimi.course.domain.model.Course;
 import com.sashimi.course.domain.model.CourseStatus;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
@@ -12,7 +13,9 @@ public interface CourseRepository {
     List<Course> findByInstructorIdAndStatus(Long instructorId, CourseStatus status);
     List<Course> findByInstructorIdAndStatusIn(Long instructorId, List<CourseStatus> statuses);
     List<Course> findByStatus(CourseStatus status);
+    List<Course> findByStatusIn(List<CourseStatus> statuses);
     List<Course> findByStatusAndCategoryId(CourseStatus status, Long categoryId);
     List<Course> findByStatusAndCategoryIdIn(CourseStatus status, List<Long> categoryIds);
+    List<Course> findByStatusAndApprovedAtBefore(CourseStatus status, LocalDateTime cutoff);
     void deleteById(Long id);
 }

--- a/src/main/java/com/sashimi/course/infrastructure/persistence/CourseRepositoryAdapter.java
+++ b/src/main/java/com/sashimi/course/infrastructure/persistence/CourseRepositoryAdapter.java
@@ -6,6 +6,7 @@ import com.sashimi.course.domain.model.CourseStatus;
 import com.sashimi.course.domain.repository.CourseRepository;
 import org.springframework.stereotype.Repository;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
@@ -86,6 +87,12 @@ public class CourseRepositoryAdapter implements CourseRepository {
     }
 
     @Override
+    public List<Course> findByStatusIn(List<CourseStatus> statuses) {
+        return springDataCourseRepository.findByStatusIn(statuses)
+                .stream().map(this::toDomain).toList();
+    }
+
+    @Override
     public List<Course> findByStatusAndCategoryId(CourseStatus status, Long categoryId) {
         return springDataCourseRepository.findByStatusAndCategoryId(status, categoryId)
                 .stream().map(this::toDomain).toList();
@@ -94,6 +101,12 @@ public class CourseRepositoryAdapter implements CourseRepository {
     @Override
     public List<Course> findByStatusAndCategoryIdIn(CourseStatus status, List<Long> categoryIds) {
         return springDataCourseRepository.findByStatusAndCategoryIdIn(status, categoryIds)
+                .stream().map(this::toDomain).toList();
+    }
+
+    @Override
+    public List<Course> findByStatusAndApprovedAtBefore(CourseStatus status, LocalDateTime cutoff) {
+        return springDataCourseRepository.findByStatusAndApprovedAtBefore(status, cutoff)
                 .stream().map(this::toDomain).toList();
     }
 

--- a/src/main/java/com/sashimi/course/infrastructure/persistence/SpringDataCourseRepository.java
+++ b/src/main/java/com/sashimi/course/infrastructure/persistence/SpringDataCourseRepository.java
@@ -3,12 +3,15 @@ package com.sashimi.course.infrastructure.persistence;
 import com.sashimi.course.domain.model.CourseStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 public interface SpringDataCourseRepository extends JpaRepository<CourseJpaEntity, Long> {
     List<CourseJpaEntity> findByInstructorIdAndStatus(Long instructorId, CourseStatus status);
     List<CourseJpaEntity> findByInstructorIdAndStatusIn(Long instructorId, List<CourseStatus> statuses);
     List<CourseJpaEntity> findByStatus(CourseStatus status);
+    List<CourseJpaEntity> findByStatusIn(List<CourseStatus> statuses);
     List<CourseJpaEntity> findByStatusAndCategoryId(CourseStatus status, Long categoryId);
     List<CourseJpaEntity> findByStatusAndCategoryIdIn(CourseStatus status, List<Long> categoryIds);
+    List<CourseJpaEntity> findByStatusAndApprovedAtBefore(CourseStatus status, LocalDateTime approvedAt);
 }

--- a/src/main/java/com/sashimi/course/presentation/api/AdminCourseController.java
+++ b/src/main/java/com/sashimi/course/presentation/api/AdminCourseController.java
@@ -36,8 +36,21 @@ public class AdminCourseController {
     }
 
     @GetMapping
-    public ResponseEntity<List<AdminCourseListResponse>> getApprovedCourses() {
-        List<AdminCourseListResponse> courses = courseQueryUseCase.getApprovedCoursesForAdmin()
+    public ResponseEntity<List<AdminCourseListResponse>> getAllCourses() {
+        List<AdminCourseListResponse> courses = courseQueryUseCase.getAllCoursesForAdmin()
+                .stream()
+                .map(course -> AdminCourseListResponse.of(
+                        course,
+                        categoryPort.getCategoryNameById(course.getCategoryId()),
+                        instructorPort.getInstructorName(course.getInstructorId())
+                ))
+                .toList();
+        return ResponseEntity.ok(courses);
+    }
+
+    @GetMapping("/closed")
+    public ResponseEntity<List<AdminCourseListResponse>> getClosedCourses() {
+        List<AdminCourseListResponse> courses = courseQueryUseCase.getClosedCoursesForAdmin()
                 .stream()
                 .map(course -> AdminCourseListResponse.of(
                         course,

--- a/src/main/java/com/sashimi/course/presentation/api/InstructorCourseController.java
+++ b/src/main/java/com/sashimi/course/presentation/api/InstructorCourseController.java
@@ -46,6 +46,14 @@ public class InstructorCourseController {
         return ResponseEntity.ok(courses);
     }
 
+    @GetMapping("/closed")
+    public ResponseEntity<List<ApprovedCourseResponse>> getClosedCourses(
+            @AuthenticationPrincipal CustomUserPrincipal principal) {
+        List<ApprovedCourseResponse> courses = courseQueryUseCase.getClosedCoursesByInstructor(principal.getId())
+                .stream().map(ApprovedCourseResponse::from).toList();
+        return ResponseEntity.ok(courses);
+    }
+
     @GetMapping("/{courseId}")
     public ResponseEntity<InstructorCourseDetailResponse> getCourseDetail(
             @AuthenticationPrincipal CustomUserPrincipal principal,

--- a/src/main/java/com/sashimi/course/presentation/api/InstructorCourseController.java
+++ b/src/main/java/com/sashimi/course/presentation/api/InstructorCourseController.java
@@ -9,8 +9,10 @@ import com.sashimi.course.presentation.api.response.ApprovedCourseResponse;
 import com.sashimi.course.presentation.api.response.CourseResponse;
 import com.sashimi.course.presentation.api.response.InstructorCourseDetailResponse;
 import com.sashimi.member.presentation.api.response.ApiResponse;
+import com.sashimi.security.principal.CustomUserPrincipal;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -30,37 +32,37 @@ public class InstructorCourseController {
 
     @GetMapping("/approved")
     public ResponseEntity<List<ApprovedCourseResponse>> getApprovedCourses(
-            @RequestHeader("X-USER-ID") Long instructorId) {
-        List<ApprovedCourseResponse> courses = courseQueryUseCase.getApprovedCoursesByInstructor(instructorId)
+            @AuthenticationPrincipal CustomUserPrincipal principal) {
+        List<ApprovedCourseResponse> courses = courseQueryUseCase.getApprovedCoursesByInstructor(principal.getId())
                 .stream().map(ApprovedCourseResponse::from).toList();
         return ResponseEntity.ok(courses);
     }
 
     @GetMapping("/in-progress")
     public ResponseEntity<List<CourseResponse>> getInProgressCourses(
-            @RequestHeader("X-USER-ID") Long instructorId) {
-        List<CourseResponse> courses = courseQueryUseCase.getInProgressCoursesByInstructor(instructorId)
+            @AuthenticationPrincipal CustomUserPrincipal principal) {
+        List<CourseResponse> courses = courseQueryUseCase.getInProgressCoursesByInstructor(principal.getId())
                 .stream().map(CourseResponse::from).toList();
         return ResponseEntity.ok(courses);
     }
 
     @GetMapping("/{courseId}")
     public ResponseEntity<InstructorCourseDetailResponse> getCourseDetail(
-            @RequestHeader("X-USER-ID") Long instructorId,
+            @AuthenticationPrincipal CustomUserPrincipal principal,
             @PathVariable Long courseId) {
-        return ResponseEntity.ok(InstructorCourseDetailResponse.from(courseQueryUseCase.getCourseDetail(courseId, instructorId)));
+        return ResponseEntity.ok(InstructorCourseDetailResponse.from(courseQueryUseCase.getCourseDetail(courseId, principal.getId())));
     }
 
     @PostMapping
     public ResponseEntity<ApiResponse<Void>> createCourse(
-            @RequestHeader("X-USER-ID") Long instructorId,
+            @AuthenticationPrincipal CustomUserPrincipal principal,
             @RequestBody CreateCourseRequest request) {
         List<CreateSessionCommand> sessionCommands = request.sessions().stream()
                 .map(s -> new CreateSessionCommand(s.title(), s.videoUrl(), 0, 0, s.preview(), null, null, null, null))
                 .toList();
 
         Long courseId = courseCommandUseCase.createCourse(new CreateCourseCommand(
-                instructorId, request.subCategoryName(), request.title(), request.description(),
+                principal.getId(), request.subCategoryName(), request.title(), request.description(),
                 request.price(), request.difficulty(), request.thumbnail(),
                 request.ncsInfoId(), request.initialStatus(), sessionCommands));
 
@@ -69,7 +71,7 @@ public class InstructorCourseController {
 
     @PutMapping("/{courseId}")
     public ResponseEntity<Void> updateCourse(
-            @RequestHeader("X-USER-ID") Long instructorId,
+            @AuthenticationPrincipal CustomUserPrincipal principal,
             @PathVariable Long courseId,
             @RequestBody UpdateCourseRequest request) {
         List<CreateSessionCommand> sessionCommands = request.sessions().stream()
@@ -77,7 +79,7 @@ public class InstructorCourseController {
                 .toList();
 
         courseCommandUseCase.updateCourse(new UpdateCourseCommand(
-                courseId, instructorId, request.categoryId(), request.title(), request.description(),
+                courseId, principal.getId(), request.categoryId(), request.title(), request.description(),
                 request.price(), request.difficulty(), request.thumbnail(),
                 request.ncsInfoId(), request.targetStatus(), sessionCommands));
 
@@ -86,9 +88,9 @@ public class InstructorCourseController {
 
     @DeleteMapping("/{courseId}")
     public ResponseEntity<Void> deleteCourse(
-            @RequestHeader("X-USER-ID") Long instructorId,
+            @AuthenticationPrincipal CustomUserPrincipal principal,
             @PathVariable Long courseId) {
-        courseCommandUseCase.deleteCourse(new DeleteCourseCommand(courseId, instructorId));
+        courseCommandUseCase.deleteCourse(new DeleteCourseCommand(courseId, principal.getId()));
         return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/com/sashimi/course/presentation/api/response/AdminCourseListResponse.java
+++ b/src/main/java/com/sashimi/course/presentation/api/response/AdminCourseListResponse.java
@@ -1,6 +1,7 @@
 package com.sashimi.course.presentation.api.response;
 
 import com.sashimi.course.domain.model.Course;
+import com.sashimi.course.domain.model.CourseStatus;
 
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
@@ -12,6 +13,7 @@ public record AdminCourseListResponse(
         String instructorName,
         int studentCount,
         BigDecimal ratingAvg,
+        CourseStatus status,
         LocalDateTime approvedAt
 ) {
     public static AdminCourseListResponse of(Course course, String categoryName, String instructorName) {
@@ -22,6 +24,7 @@ public record AdminCourseListResponse(
                 instructorName,
                 course.getStudentCount(),
                 course.getRatingAvg(),
+                course.getStatus(),
                 course.getApprovedAt()
         );
     }

--- a/src/main/java/com/sashimi/course/scheduler/CoursePublicationScheduler.java
+++ b/src/main/java/com/sashimi/course/scheduler/CoursePublicationScheduler.java
@@ -1,0 +1,22 @@
+package com.sashimi.course.scheduler;
+
+import com.sashimi.course.application.usecase.CourseCommandUseCase;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class CoursePublicationScheduler {
+
+    private final CourseCommandUseCase courseCommandUseCase;
+
+    @Scheduled(cron = "0 0 0 * * *")
+    public void closeExpiredCourses() {
+        log.info("[CoursePublication] 공개 기간 만료 강의 비공개 처리 시작");
+        int closed = courseCommandUseCase.closeExpiredCourses();
+        log.info("[CoursePublication] 공개 기간 만료 강의 비공개 처리 완료 - {}건", closed);
+    }
+}

--- a/src/main/java/com/sashimi/enrollment/application/service/StudentCourseQueryService.java
+++ b/src/main/java/com/sashimi/enrollment/application/service/StudentCourseQueryService.java
@@ -9,6 +9,7 @@ import com.sashimi.enrollment.application.query.EnrolledCourseView;
 import com.sashimi.enrollment.application.usecase.StudentCourseQueryUseCase;
 import com.sashimi.global.exception.BusinessException;
 import com.sashimi.global.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -18,15 +19,11 @@ import java.util.List;
 @Slf4j
 @Service
 @Transactional(readOnly = true)
+@RequiredArgsConstructor
 public class StudentCourseQueryService implements StudentCourseQueryUseCase {
 
     private final EnrollmentPort enrollmentPort;
     private final CoursePort coursePort;
-
-    public StudentCourseQueryService(EnrollmentPort enrollmentPort, CoursePort coursePort) {
-        this.enrollmentPort = enrollmentPort;
-        this.coursePort = coursePort;
-    }
 
     @Override
     public List<EnrolledCourseView> getEnrolledCourses(Long userId) {

--- a/src/main/java/com/sashimi/enrollment/application/service/StudentCourseQueryService.java
+++ b/src/main/java/com/sashimi/enrollment/application/service/StudentCourseQueryService.java
@@ -14,6 +14,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 @Slf4j
@@ -22,12 +23,16 @@ import java.util.List;
 @RequiredArgsConstructor
 public class StudentCourseQueryService implements StudentCourseQueryUseCase {
 
+    /** 강의 구매일(수강 등록일) 기준 수강 가능 기간 (년) */
+    private static final int ACCESS_PERIOD_YEARS = 2;
+
     private final EnrollmentPort enrollmentPort;
     private final CoursePort coursePort;
 
     @Override
     public List<EnrolledCourseView> getEnrolledCourses(Long userId) {
         return enrollmentPort.getEnrollmentsByUser(userId).stream()
+                .filter(summary -> !isAccessExpired(summary.enrolledAt()))
                 .map(summary -> {
                     EnrolledCourseInfo courseInfo = coursePort.getCourseInfo(summary.courseId());
                     return new EnrolledCourseView(
@@ -46,10 +51,21 @@ public class StudentCourseQueryService implements StudentCourseQueryUseCase {
     public EnrolledCourseDetailView getEnrolledCourseDetail(Long userId, Long courseId) {
         EnrollmentSummary summary = enrollmentPort.getEnrollmentByCourse(userId, courseId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.COURSE_FORBIDDEN));
+        if (isAccessExpired(summary.enrolledAt())) {
+            throw new BusinessException(ErrorCode.ENROLLMENT_EXPIRED);
+        }
         return new EnrolledCourseDetailView(
                 coursePort.getCourseDetailInfo(courseId),
                 summary.progressRate(),
                 summary.completed()
         );
+    }
+
+    /** 구매일로부터 수강 가능 기간이 지났는지 여부 */
+    private boolean isAccessExpired(LocalDateTime enrolledAt) {
+        if (enrolledAt == null) {
+            return false;
+        }
+        return enrolledAt.isBefore(LocalDateTime.now().minusYears(ACCESS_PERIOD_YEARS));
     }
 }

--- a/src/main/java/com/sashimi/enrollment/presentation/api/StudentCourseController.java
+++ b/src/main/java/com/sashimi/enrollment/presentation/api/StudentCourseController.java
@@ -3,7 +3,9 @@ package com.sashimi.enrollment.presentation.api;
 import com.sashimi.enrollment.application.usecase.StudentCourseQueryUseCase;
 import com.sashimi.enrollment.presentation.api.response.EnrolledCourseDetailResponse;
 import com.sashimi.enrollment.presentation.api.response.EnrolledCourseResponse;
+import com.sashimi.security.principal.CustomUserPrincipal;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -20,18 +22,18 @@ public class StudentCourseController {
 
     @GetMapping
     public ResponseEntity<List<EnrolledCourseResponse>> getEnrolledCourses(
-            @RequestHeader("X-USER-ID") Long userId) {
-        List<EnrolledCourseResponse> response = studentCourseQueryUseCase.getEnrolledCourses(userId)
+            @AuthenticationPrincipal CustomUserPrincipal principal) {
+        List<EnrolledCourseResponse> response = studentCourseQueryUseCase.getEnrolledCourses(principal.getId())
                 .stream().map(EnrolledCourseResponse::from).toList();
         return ResponseEntity.ok(response);
     }
 
     @GetMapping("/{courseId}")
     public ResponseEntity<EnrolledCourseDetailResponse> getEnrolledCourseDetail(
-            @RequestHeader("X-USER-ID") Long userId,
+            @AuthenticationPrincipal CustomUserPrincipal principal,
             @PathVariable Long courseId) {
         return ResponseEntity.ok(EnrolledCourseDetailResponse.from(
-                studentCourseQueryUseCase.getEnrolledCourseDetail(userId, courseId)
+                studentCourseQueryUseCase.getEnrolledCourseDetail(principal.getId(), courseId)
         ));
     }
 }

--- a/src/main/java/com/sashimi/global/exception/ErrorCode.java
+++ b/src/main/java/com/sashimi/global/exception/ErrorCode.java
@@ -54,6 +54,7 @@ public enum ErrorCode {
 
     ENROLLMENT_ALREADY_EXISTS(409, "ENROLLMENT_001", "이미 수강 중인 강의입니다."),
     ENROLLMENT_CREATE_FAILED(500, "ENROLLMENT_002", "수강 등록에 실패했습니다."),
+    ENROLLMENT_EXPIRED(403, "ENROLLMENT_003", "수강 가능 기간이 만료되었습니다."),
 
     PAYMENT_ORDER_NOT_FOUND(404, "PAYMENT_001", "주문을 찾을 수 없습니다."),
     PAYMENT_EMPTY_COURSE(400, "PAYMENT_002", "결제할 강의가 없습니다."),


### PR DESCRIPTION
## 📌 PR 요약
- 수강생 강의 기한 2년 설정
- 승인일 2년 지난 강의 비공개 상태 기능 추가 

---

## 🛠️ 작업 상세 내용 (체크로 선택)
- [ ] ✨ FEATURE
- [ ] 🔧 UPDATE
- [ ] 🐛 BUGFIX
- [ ] ♻️ REFACTOR
- [ ] 📝 DOCS

---

## 📋 작업 상세 내용
- 수강생은 강의를 구매한 지 2년 이내인 강의만 자신의 강의에서 조회가 가능하며
구매한 지 2년이 지난 강의는 접근이 불가하다
- 관리자로부터 승인 받은지 2년인 지난 강의는 상태값이 비공개로 변경되고, 강의 조회 시 
비공개인 강의들은 조회되지 않도록 구현
- 비공개 강의 추가에 따른 강의 조회 api 전체 수정 

---

## 🔗 PR 관련 이슈로 닫기
Closes #217 
Closes #218 
Closes #191 

---

## ✅ 체크리스트 (확인 절차)
- [ ] 정상적으로 빌드 및 실행됩니다.
- [ ] 주요 기능이 정상 동작합니다.
- [ ] 불필요한 코드를 제거했습니다.
- [ ] 코드 리뷰 준비가 완료되었습니다.

---

## 💬 리뷰어에게 할 말
- 

---

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 승인일로부터 2년 경과 시 강의가 자동으로 비공개 처리됩니다.
  * 강사 및 관리자가 비공개된 강의를 조회할 수 있습니다.
  * 수강 가능 기간 만료 시 학생의 접근이 제한됩니다.

* **Refactor**
  * 사용자 식별 방식이 요청 헤더에서 인증 정보 기반으로 변경되었습니다.

* **Bug Fixes**
  * 만료된 수강 과정의 접근 제어가 강화되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->