### PR TITLE
[UPDATE] #229, #244 단일 강의 결제 및 장바구니 결제 조회 기능 나누기 및 결제하기 기능 통일 완료

### DIFF
--- a/src/main/java/com/sashimi/cart/application/service/CartQueryService.java
+++ b/src/main/java/com/sashimi/cart/application/service/CartQueryService.java
@@ -5,8 +5,6 @@ import com.sashimi.cart.application.port.CoursePort;
 import com.sashimi.cart.application.usecase.CartQueryUseCase;
 import com.sashimi.cart.domain.model.CartItem;
 import com.sashimi.cart.domain.repository.CartItemRepository;
-import com.sashimi.global.exception.BusinessException;
-import com.sashimi.global.exception.ErrorCode;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -33,16 +31,6 @@ public class CartQueryService implements CartQueryUseCase {
         return toCartView(cartItems);
     }
 
-    @Override
-    public CartView getCheckoutCart(Long userId) {
-        List<CartItem> cartItems = cartItemRepository.findAllSelectedByUserId(userId);
-
-        if (cartItems.isEmpty()) {
-            throw new BusinessException(ErrorCode.CART_EMPTY_SELECTION);
-        }
-
-        return toCartView(cartItems);
-    }
 
     private CartView toCartView(List<CartItem> cartItems) {
         List<CartItemView> itemViews = cartItems.stream()

--- a/src/main/java/com/sashimi/cart/application/usecase/CartQueryUseCase.java
+++ b/src/main/java/com/sashimi/cart/application/usecase/CartQueryUseCase.java
@@ -6,7 +6,6 @@ public interface CartQueryUseCase {
 
     CartView getCart(Long userId);
 
-    CartView getCheckoutCart(Long userId);
 
     record CartView(
             List<CartItemView> items,

--- a/src/main/java/com/sashimi/cart/presentation/api/CartController.java
+++ b/src/main/java/com/sashimi/cart/presentation/api/CartController.java
@@ -172,19 +172,5 @@ public class CartController {
         return ResponseEntity.noContent().build();
     }
 
-    @Operation(summary = "장바구니 결제 전 조회", description = "결제 대상으로 선택된 장바구니 항목과 총 금액을 조회합니다.")
-    @ApiResponses({
-            @ApiResponse(responseCode = "200", description = "결제 대상 조회 성공"),
-            @ApiResponse(responseCode = "400", description = "선택된 장바구니 항목이 없음"),
-            @ApiResponse(responseCode = "401", description = "인증 실패")
-    })
-    @PostMapping("/checkout")
-    public ResponseEntity<CartResponse> checkout(
-            @AuthenticationPrincipal CustomUserPrincipal principal
-    ) {
-        CartQueryUseCase.CartView cartView =
-                cartQueryUseCase.getCheckoutCart(principal.getId());
 
-        return ResponseEntity.ok(CartResponse.from(cartView));
-    }
 }

--- a/src/main/java/com/sashimi/cart/presentation/api/request.http
+++ b/src/main/java/com/sashimi/cart/presentation/api/request.http
@@ -57,7 +57,3 @@ Authorization: Bearer {{accessToken}}
   "cartItemIds": [1, 2, 3]
 }
 
-### 장바구니 결제 전 조회
-POST {{baseUrl}}/cart/checkout
-Accept: application/json
-Authorization: Bearer {{accessToken}}

--- a/src/main/java/com/sashimi/credit/presentation/api/CreditController.java
+++ b/src/main/java/com/sashimi/credit/presentation/api/CreditController.java
@@ -24,6 +24,9 @@ import com.sashimi.credit.presentation.api.request.ConfirmCreditChargeRequest;
 import com.sashimi.credit.presentation.api.request.ReadyCreditChargeRequest;
 import com.sashimi.credit.presentation.api.response.CreditChargeConfirmResponse;
 import com.sashimi.credit.presentation.api.response.CreditChargeReadyResponse;
+import com.sashimi.global.exception.ErrorResponse;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
 
 @Tag(name = "Credit", description = "크레딧 API")
 @SecurityRequirement(name = "bearerAuth")
@@ -50,6 +53,34 @@ public class CreditController {
         return ResponseEntity.ok(CreditResponse.from(result));
     }
 
+
+    @Operation(
+            summary = "Toss 크레딧 충전 준비",
+            description = "충전 금액을 검증하고 Toss 결제에 사용할 주문번호, 주문명 및 결제 금액을 생성합니다."
+    )
+    @ApiResponses({
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "충전 준비 성공",
+                    content = @Content(schema = @Schema(
+                            implementation = CreditChargeReadyResponse.class
+                    ))
+            ),
+            @ApiResponse(
+                    responseCode = "400",
+                    description = "충전 금액이 최소 금액보다 작거나 1,000 단위가 아님",
+                    content = @Content(schema = @Schema(
+                            implementation = ErrorResponse.class
+                    ))
+            ),
+            @ApiResponse(
+                    responseCode = "401",
+                    description = "인증 실패",
+                    content = @Content(schema = @Schema(
+                            implementation = ErrorResponse.class
+                    ))
+            )
+    })
     @PostMapping("/toss/ready")
     public ResponseEntity<CreditChargeReadyResponse> readyCreditCharge(
             @AuthenticationPrincipal CustomUserPrincipal principal,
@@ -62,6 +93,62 @@ public class CreditController {
         return ResponseEntity.ok(CreditChargeReadyResponse.from(result));
     }
 
+
+    @Operation(
+            summary = "Toss 크레딧 충전 승인",
+            description = "Toss 결제 성공 정보를 검증하고 Toss 승인 API 호출 성공 후 사용자의 크레딧을 충전합니다."
+    )
+    @ApiResponses({
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "충전 승인 및 크레딧 충전 성공",
+                    content = @Content(schema = @Schema(
+                            implementation = CreditChargeConfirmResponse.class
+                    ))
+            ),
+            @ApiResponse(
+                    responseCode = "400",
+                    description = "결제 금액 불일치 또는 잘못된 요청",
+                    content = @Content(schema = @Schema(
+                            implementation = ErrorResponse.class
+                    ))
+            ),
+            @ApiResponse(
+                    responseCode = "401",
+                    description = "인증 실패",
+                    content = @Content(schema = @Schema(
+                            implementation = ErrorResponse.class
+                    ))
+            ),
+            @ApiResponse(
+                    responseCode = "403",
+                    description = "다른 사용자의 충전 주문에 접근",
+                    content = @Content(schema = @Schema(
+                            implementation = ErrorResponse.class
+                    ))
+            ),
+            @ApiResponse(
+                    responseCode = "404",
+                    description = "충전 준비 주문을 찾을 수 없음",
+                    content = @Content(schema = @Schema(
+                            implementation = ErrorResponse.class
+                    ))
+            ),
+            @ApiResponse(
+                    responseCode = "409",
+                    description = "이미 처리된 충전 결제",
+                    content = @Content(schema = @Schema(
+                            implementation = ErrorResponse.class
+                    ))
+            ),
+            @ApiResponse(
+                    responseCode = "502",
+                    description = "Toss 외부 결제 승인 실패",
+                    content = @Content(schema = @Schema(
+                            implementation = ErrorResponse.class
+                    ))
+            )
+    })
     @PostMapping("/toss/confirm")
     public ResponseEntity<CreditChargeConfirmResponse> confirmCreditCharge(
             @AuthenticationPrincipal CustomUserPrincipal principal,

--- a/src/main/java/com/sashimi/credit/presentation/api/request.http
+++ b/src/main/java/com/sashimi/credit/presentation/api/request.http
@@ -1,27 +1,29 @@
 @baseUrl = http://localhost:8080
-@accessToken = eyJhbGciOiJIUzM4NCJ9.eyJzdWIiOiJzdHVkZW50MDEiLCJhdXRoIjoiUk9MRV9TVFVERU5UIiwiaWF0IjoxNzgwMDI2MTcyLCJleHAiOjE3ODAwMzY5NzJ9.SIOmYTR2cChmC1yLPoDonJd0bBKCBjx_CFKFgTFbMGLR4sQxfUiG87HtAKcvpVxL
-
-### 로그인
-POST {{baseUrl}}/auth/login
-Content-Type: application/json
-Accept: application/json
-
-{
-  "loginId": "student01",
-  "password": "student"
-}
+@accessToken = 로그인 후 발급받은 accessToken
 
 ### 내 크레딧 조회
 GET {{baseUrl}}/credits/me
 Accept: application/json
 Authorization: Bearer {{accessToken}}
 
-### 크레딧 충전
-POST {{baseUrl}}/credits/charge
+### Toss 크레딧 충전 준비
+POST {{baseUrl}}/credits/toss/ready
 Content-Type: application/json
 Accept: application/json
 Authorization: Bearer {{accessToken}}
 
 {
-  "amount": 100000
+  "amount": 30000
+}
+
+### Toss 크레딧 충전 승인
+POST {{baseUrl}}/credits/toss/confirm
+Content-Type: application/json
+Accept: application/json
+Authorization: Bearer {{accessToken}}
+
+{
+  "paymentKey": "TOSS가 전달한 paymentKey",
+  "orderId": "ready 응답의 orderId",
+  "amount": 30000
 }

--- a/src/main/java/com/sashimi/global/exception/ErrorCode.java
+++ b/src/main/java/com/sashimi/global/exception/ErrorCode.java
@@ -62,6 +62,10 @@ public enum ErrorCode {
     PAYMENT_INVALID_STATUS(400, "PAYMENT_005", "처리할 수 없는 결제 상태입니다."),
     PAYMENT_AMOUNT_MISMATCH(400, "PAYMENT_006", "결제 금액이 일치하지 않습니다."),
     PAYMENT_APPROVAL_FAILED(502, "PAYMENT_007", "외부 결제 승인에 실패했습니다."),
+    PAYMENT_INVALID_CHECKOUT_REQUEST(400, "PAYMENT_008", "결제 요청 정보가 올바르지 않습니다."),
+    PAYMENT_AGREEMENT_REQUIRED(400, "PAYMENT_009", "결제 진행을 위해 결제 동의가 필요합니다."),
+    PAYMENT_COURSE_ID_REQUIRED(400, "PAYMENT_010", "단일 강의 결제에는 강의 ID가 필요합니다."),
+    PAYMENT_CART_COURSE_ID_NOT_ALLOWED(400, "PAYMENT_011", "장바구니 결제에는 강의 ID를 전달할 수 없습니다."),
 
     CREDIT_INVALID_AMOUNT(400, "CREDIT_001", "크레딧 금액이 올바르지 않습니다."),
     CREDIT_INSUFFICIENT_BALANCE(400, "CREDIT_002", "크레딧 잔액이 부족합니다."),

--- a/src/main/java/com/sashimi/payment/application/command/CheckoutCartCommand.java
+++ b/src/main/java/com/sashimi/payment/application/command/CheckoutCartCommand.java
@@ -1,4 +1,0 @@
-package com.sashimi.payment.application.command;
-
-public record CheckoutCartCommand(Long userId) {
-}

--- a/src/main/java/com/sashimi/payment/application/command/PayCourseCommand.java
+++ b/src/main/java/com/sashimi/payment/application/command/PayCourseCommand.java
@@ -1,4 +1,0 @@
-package com.sashimi.payment.application.command;
-
-public record PayCourseCommand(Long userId, Long courseId) {
-}

--- a/src/main/java/com/sashimi/payment/application/command/PaymentCheckoutCommand.java
+++ b/src/main/java/com/sashimi/payment/application/command/PaymentCheckoutCommand.java
@@ -1,0 +1,11 @@
+package com.sashimi.payment.application.command;
+
+public record PaymentCheckoutCommand(
+
+        Long userId,
+        PaymentPurchaseType purchaseType,
+        Long courseId,
+        Boolean agreed
+
+) {
+}

--- a/src/main/java/com/sashimi/payment/application/command/PaymentPurchaseType.java
+++ b/src/main/java/com/sashimi/payment/application/command/PaymentPurchaseType.java
@@ -1,0 +1,6 @@
+package com.sashimi.payment.application.command;
+
+public enum PaymentPurchaseType {
+    COURSE,
+    CART
+}

--- a/src/main/java/com/sashimi/payment/application/service/PaymentCommandService.java
+++ b/src/main/java/com/sashimi/payment/application/service/PaymentCommandService.java
@@ -9,8 +9,7 @@ import com.sashimi.credit.application.usecase.CreditCommandUseCase;
 import com.sashimi.enrollment.application.port.EnrollmentPort;
 import com.sashimi.global.exception.BusinessException;
 import com.sashimi.global.exception.ErrorCode;
-import com.sashimi.payment.application.command.CheckoutCartCommand;
-import com.sashimi.payment.application.command.PayCourseCommand;
+import com.sashimi.payment.application.command.PaymentCheckoutCommand;
 import com.sashimi.payment.application.usecase.PaymentCommandUseCase;
 import com.sashimi.order.domain.model.Order;
 import com.sashimi.order.domain.model.OrderItem;
@@ -59,53 +58,57 @@ public class PaymentCommandService implements PaymentCommandUseCase {
     }
 
     @Override
-    public PaymentResult checkoutCart(CheckoutCartCommand command) {
-        log.info("장바구니 결제 요청 - userId={}", command.userId());
+    public PaymentResult checkout(PaymentCheckoutCommand command) {
+        if (!Boolean.TRUE.equals(command.agreed())) {
+            throw new BusinessException(ErrorCode.PAYMENT_AGREEMENT_REQUIRED);
+        }
 
-        List<CartItem> cartItems = cartItemRepository.findAllSelectedByUserId(command.userId());
+        if (command.purchaseType() == null) {
+            throw new BusinessException(ErrorCode.PAYMENT_INVALID_CHECKOUT_REQUEST);
+        }
+
+        return switch (command.purchaseType()) {
+            case COURSE -> checkoutCourse(command.userId(), command.courseId());
+            case CART -> checkoutCart(command.userId(), command.courseId());
+        };
+    }
+
+    private PaymentResult checkoutCourse(Long userId, Long courseId) {
+        if (courseId == null || courseId <= 0) {
+            throw new BusinessException(ErrorCode.PAYMENT_COURSE_ID_REQUIRED);
+        }
+
+        CourseInfo course = coursePurchasePolicy.validatePurchasable(userId, courseId);
+
+        PaymentResult result = pay(userId, List.of(
+                new PaymentCourse(course.courseId(), course.title(), course.price())
+        ), PaymentSource.DIRECT);
+
+        cartItemRepository.deleteByUserIdAndCourseId(userId, courseId);
+        return result;
+    }
+
+    private PaymentResult checkoutCart(Long userId, Long courseId) {
+        if (courseId != null) {
+            throw new BusinessException(ErrorCode.PAYMENT_CART_COURSE_ID_NOT_ALLOWED);
+        }
+
+        List<CartItem> cartItems = cartItemRepository.findAllSelectedByUserId(userId);
 
         if (cartItems.isEmpty()) {
             throw new BusinessException(ErrorCode.CART_EMPTY_SELECTION);
         }
 
         List<PaymentCourse> courses = cartItems.stream()
-                .map(cartItem -> {
-                    CourseInfo courseInfo = coursePurchasePolicy.validatePurchasable(
-                            command.userId(),
-                            cartItem.getCourseId()
-                    );
-
-                    return new PaymentCourse(
-                            courseInfo.courseId(),
-                            courseInfo.title(),
-                            courseInfo.price()
-                    );
-                })
+                .map(item -> coursePurchasePolicy.validatePurchasable(
+                        userId, item.getCourseId()
+                ))
+                .map(course -> new PaymentCourse(
+                        course.courseId(), course.title(), course.price()
+                ))
                 .toList();
 
-        return pay(command.userId(), courses, PaymentSource.CART);
-    }
-
-    @Override
-    public PaymentResult payCourse(PayCourseCommand command) {
-        log.info("단일 강의 결제 요청 - userId={}, courseId={}",
-                command.userId(), command.courseId());
-
-        CourseInfo courseInfo = coursePurchasePolicy.validatePurchasable(
-                command.userId(),
-                command.courseId()
-        );
-
-        PaymentResult result = pay(command.userId(), List.of(
-                new PaymentCourse(courseInfo.courseId(), courseInfo.title(), courseInfo.price())
-        ), PaymentSource.DIRECT);
-
-        cartItemRepository.deleteByUserIdAndCourseId(
-                command.userId(),
-                command.courseId()
-        );
-
-        return result;
+        return pay(userId, courses, PaymentSource.CART);
     }
 
     private PaymentResult pay(Long userId, List<PaymentCourse> courses, PaymentSource source) {

--- a/src/main/java/com/sashimi/payment/application/service/PaymentQueryService.java
+++ b/src/main/java/com/sashimi/payment/application/service/PaymentQueryService.java
@@ -1,12 +1,20 @@
 package com.sashimi.payment.application.service;
 
+import com.sashimi.cart.application.port.CourseInfo;
+import com.sashimi.cart.domain.model.CartItem;
+import com.sashimi.cart.domain.repository.CartItemRepository;
+import com.sashimi.credit.application.usecase.CreditQueryUseCase;
 import com.sashimi.global.exception.BusinessException;
 import com.sashimi.global.exception.ErrorCode;
+import com.sashimi.order.application.policy.CoursePurchasePolicy;
+import com.sashimi.order.domain.repository.OrderItemRepository;
 import com.sashimi.payment.application.usecase.PaymentQueryUseCase;
 import com.sashimi.order.domain.model.Order;
 import com.sashimi.payment.domain.model.Payment;
 import com.sashimi.order.domain.repository.OrderRepository;
 import com.sashimi.payment.domain.repository.PaymentRepository;
+import com.sashimi.order.domain.model.OrderItem;
+import com.sashimi.order.domain.model.OrderItemType;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -18,10 +26,18 @@ public class PaymentQueryService implements PaymentQueryUseCase {
 
     private final PaymentRepository paymentRepository;
     private final OrderRepository orderRepository;
+    private final CartItemRepository cartItemRepository;
+    private final CoursePurchasePolicy coursePurchasePolicy;
+    private final CreditQueryUseCase creditQueryUseCase;
+    private final OrderItemRepository orderItemRepository;
 
-    public PaymentQueryService(PaymentRepository paymentRepository, OrderRepository orderRepository) {
+    public PaymentQueryService(PaymentRepository paymentRepository, OrderRepository orderRepository, CartItemRepository cartItemRepository, CoursePurchasePolicy coursePurchasePolicy, CreditQueryUseCase creditQueryUseCase, OrderItemRepository orderItemRepository) {
         this.paymentRepository = paymentRepository;
         this.orderRepository = orderRepository;
+        this.cartItemRepository = cartItemRepository;
+        this.coursePurchasePolicy = coursePurchasePolicy;
+        this.creditQueryUseCase = creditQueryUseCase;
+        this.orderItemRepository = orderItemRepository;
     }
 
     @Override
@@ -36,7 +52,16 @@ public class PaymentQueryService implements PaymentQueryUseCase {
 
     private PaymentHistoryItem toHistoryItem(Payment payment) {
         Order order = orderRepository.findById(payment.getOrderId())
-                .orElseThrow(() -> new BusinessException(ErrorCode.PAYMENT_ORDER_NOT_FOUND));
+                .orElseThrow(() ->
+                        new BusinessException(ErrorCode.PAYMENT_ORDER_NOT_FOUND)
+                );
+
+        List<PaymentHistoryCourse> courses =
+                orderItemRepository.findAllByOrderId(order.getId())
+                        .stream()
+                        .filter(item -> item.getItemType() == OrderItemType.COURSE)
+                        .map(this::toHistoryCourse)
+                        .toList();
 
         return new PaymentHistoryItem(
                 payment.getId(),
@@ -46,7 +71,72 @@ public class PaymentQueryService implements PaymentQueryUseCase {
                 payment.getStatus().name(),
                 order.getStatus().name(),
                 payment.getPaidAt(),
-                payment.getCreatedAt()
+                payment.getCreatedAt(),
+                courses
+        );
+    }
+
+    private PaymentHistoryCourse toHistoryCourse(OrderItem item) {
+        return new PaymentHistoryCourse(
+                item.getCourseId(),
+                item.getCourseTitle(),
+                item.getFinalPrice()
+        );
+    }
+
+    @Override
+    public PaymentPreview getCoursePreview(Long userId, Long courseId) {
+        CourseInfo course = coursePurchasePolicy.validatePurchasable(userId, courseId);
+        return createPreview("COURSE", List.of(toPreviewCourse(course)), userId);
+    }
+
+    @Override
+    public PaymentPreview getCartPreview(Long userId) {
+        List<CartItem> items = cartItemRepository.findAllSelectedByUserId(userId);
+
+        if (items.isEmpty()) {
+            throw new BusinessException(ErrorCode.CART_EMPTY_SELECTION);
+        }
+
+        List<PaymentPreviewCourse> courses = items.stream()
+                .map(item -> coursePurchasePolicy.validatePurchasable(
+                        userId, item.getCourseId()
+                ))
+                .map(this::toPreviewCourse)
+                .toList();
+
+        return createPreview("CART", courses, userId);
+    }
+
+    private PaymentPreviewCourse toPreviewCourse(CourseInfo course) {
+        return new PaymentPreviewCourse(
+                course.courseId(),
+                course.title(),
+                course.thumbnail(),
+                course.instructorName(),
+                course.price()
+        );
+    }
+
+    private PaymentPreview createPreview(
+            String purchaseType,
+            List<PaymentPreviewCourse> courses,
+            Long userId
+    ) {
+        long totalAmount = courses.stream()
+                .mapToLong(PaymentPreviewCourse::price)
+                .sum();
+
+        long balance = creditQueryUseCase.getBalance(userId).balance();
+
+        return new PaymentPreview(
+                purchaseType,
+                courses,
+                totalAmount,
+                balance,
+                Math.max(balance - totalAmount, 0L),
+                Math.max(totalAmount - balance, 0L),
+                balance >= totalAmount
         );
     }
 }

--- a/src/main/java/com/sashimi/payment/application/usecase/PaymentCommandUseCase.java
+++ b/src/main/java/com/sashimi/payment/application/usecase/PaymentCommandUseCase.java
@@ -1,15 +1,13 @@
 package com.sashimi.payment.application.usecase;
 
-import com.sashimi.payment.application.command.CheckoutCartCommand;
-import com.sashimi.payment.application.command.PayCourseCommand;
+
+import com.sashimi.payment.application.command.PaymentCheckoutCommand;
 
 import java.util.List;
 
 public interface PaymentCommandUseCase {
 
-    PaymentResult checkoutCart(CheckoutCartCommand command);
-
-    PaymentResult payCourse(PayCourseCommand command);
+    PaymentResult checkout(PaymentCheckoutCommand command);
 
     record PaymentResult(
             Long orderId,

--- a/src/main/java/com/sashimi/payment/application/usecase/PaymentQueryUseCase.java
+++ b/src/main/java/com/sashimi/payment/application/usecase/PaymentQueryUseCase.java
@@ -6,6 +6,8 @@ import java.util.List;
 public interface PaymentQueryUseCase {
 
     PaymentHistory getPaymentHistory(Long userId);
+    PaymentPreview getCoursePreview(Long userId, Long courseId);
+    PaymentPreview getCartPreview(Long userId);
 
     record PaymentHistory(List<PaymentHistoryItem> items) {
     }
@@ -18,7 +20,30 @@ public interface PaymentQueryUseCase {
             String paymentStatus,
             String orderStatus,
             LocalDateTime paidAt,
-            LocalDateTime createdAt
-    ) {
-    }
+            LocalDateTime createdAt,
+            List<PaymentHistoryCourse> courses
+    ) { }
+    record PaymentHistoryCourse(
+            Long courseId,
+            String title,
+            Long price
+    ) { }
+
+    record PaymentPreview(
+            String purchaseType,
+            List<PaymentPreviewCourse> courses,
+            Long totalAmount,
+            Long creditBalance,
+            Long balanceAfterPayment,
+            Long insufficientAmount,
+            boolean payable
+    ) { }
+
+    record PaymentPreviewCourse(
+            Long courseId,
+            String title,
+            String thumbnail,
+            String instructorName,
+            Long price
+    ) { }
 }

--- a/src/main/java/com/sashimi/payment/presentation/api/PaymentController.java
+++ b/src/main/java/com/sashimi/payment/presentation/api/PaymentController.java
@@ -1,11 +1,12 @@
 package com.sashimi.payment.presentation.api;
 
 import com.sashimi.global.exception.ErrorResponse;
-import com.sashimi.payment.application.command.CheckoutCartCommand;
-import com.sashimi.payment.application.command.PayCourseCommand;
+import com.sashimi.payment.application.command.PaymentCheckoutCommand;
 import com.sashimi.payment.application.usecase.PaymentCommandUseCase;
 import com.sashimi.payment.application.usecase.PaymentQueryUseCase;
+import com.sashimi.payment.presentation.api.request.PaymentCheckoutRequest;
 import com.sashimi.payment.presentation.api.response.PaymentHistoryResponse;
+import com.sashimi.payment.presentation.api.response.PaymentPreviewResponse;
 import com.sashimi.payment.presentation.api.response.PaymentResponse;
 import com.sashimi.security.principal.CustomUserPrincipal;
 import io.swagger.v3.oas.annotations.Operation;
@@ -15,12 +16,13 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
-@Tag(name = "Payment", description = "결제 API")
+@Tag(name = "Payment", description = "강의 결제 API")
 @SecurityRequirement(name = "bearerAuth")
 @RestController
 @RequestMapping("/payments")
@@ -37,51 +39,19 @@ public class PaymentController {
         this.paymentQueryUseCase = paymentQueryUseCase;
     }
 
-    @Operation(summary = "장바구니 선택 강의 결제", description = "장바구니에서 선택한 강의들을 크레딧으로 결제합니다.")
+    @Operation(
+            summary = "단일 강의 결제 전 정보 조회",
+            description = "강의 상세에서 바로 구매한 강의의 정보, 결제 금액, 보유 크레딧 및 결제 가능 여부를 조회합니다."
+    )
     @ApiResponses({
             @ApiResponse(
-                    responseCode = "201",
-                    description = "결제 성공",
-                    content = @Content(schema = @Schema(implementation = PaymentResponse.class))
+                    responseCode = "200",
+                    description = "결제 전 정보 조회 성공",
+                    content = @Content(schema = @Schema(implementation = PaymentPreviewResponse.class))
             ),
             @ApiResponse(
                     responseCode = "400",
-                    description = "선택한 강의 없음, 구매 불가 강의, 크레딧 부족 또는 잘못된 요청",
-                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))
-            ),
-            @ApiResponse(
-                    responseCode = "401",
-                    description = "인증 실패",
-                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))
-            ),
-            @ApiResponse(
-                    responseCode = "409",
-                    description = "이미 수강 중인 강의",
-                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))
-            )
-    })
-
-    @PostMapping("/cart/checkout")
-    public ResponseEntity<PaymentResponse> checkoutCart(
-            @AuthenticationPrincipal CustomUserPrincipal principal
-    ) {
-        PaymentCommandUseCase.PaymentResult result =
-                paymentCommandUseCase.checkoutCart(new CheckoutCartCommand(principal.getId()));
-
-        return ResponseEntity.status(HttpStatus.CREATED).body(PaymentResponse.from(result));
-    }
-
-
-    @Operation(summary = "단일 강의 바로 결제", description = "특정 강의를 장바구니 없이 바로 크레딧으로 결제합니다.")
-    @ApiResponses({
-            @ApiResponse(
-                    responseCode = "201",
-                    description = "결제 성공",
-                    content = @Content(schema = @Schema(implementation = PaymentResponse.class))
-            ),
-            @ApiResponse(
-                    responseCode = "400",
-                    description = "구매 불가 강의, 크레딧 부족 또는 잘못된 요청",
+                    description = "구매할 수 없는 강의",
                     content = @Content(schema = @Schema(implementation = ErrorResponse.class))
             ),
             @ApiResponse(
@@ -100,19 +70,112 @@ public class PaymentController {
                     content = @Content(schema = @Schema(implementation = ErrorResponse.class))
             )
     })
-    @PostMapping("/course/{courseId}")
-    public ResponseEntity<PaymentResponse> payCourse(
+    @GetMapping("/course/{courseId}/preview")
+    public ResponseEntity<PaymentPreviewResponse> getCoursePreview(
             @AuthenticationPrincipal CustomUserPrincipal principal,
             @PathVariable Long courseId
     ) {
-        PaymentCommandUseCase.PaymentResult result =
-                paymentCommandUseCase.payCourse(new PayCourseCommand(principal.getId(), courseId));
+        PaymentQueryUseCase.PaymentPreview preview =
+                paymentQueryUseCase.getCoursePreview(principal.getId(), courseId);
 
-        return ResponseEntity.status(HttpStatus.CREATED).body(PaymentResponse.from(result));
+        return ResponseEntity.ok(PaymentPreviewResponse.from(preview));
     }
 
+    @Operation(
+            summary = "장바구니 선택 강의 결제 전 정보 조회",
+            description = "장바구니에서 선택된 강의 목록, 총 결제 금액, 보유 크레딧 및 결제 가능 여부를 조회합니다."
+    )
+    @ApiResponses({
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "결제 전 정보 조회 성공",
+                    content = @Content(schema = @Schema(implementation = PaymentPreviewResponse.class))
+            ),
+            @ApiResponse(
+                    responseCode = "400",
+                    description = "선택한 강의가 없거나 구매할 수 없는 강의가 포함됨",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+            ),
+            @ApiResponse(
+                    responseCode = "401",
+                    description = "인증 실패",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+            ),
+            @ApiResponse(
+                    responseCode = "409",
+                    description = "이미 수강 중인 강의가 포함됨",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+            )
+    })
+    @GetMapping("/cart/preview")
+    public ResponseEntity<PaymentPreviewResponse> getCartPreview(
+            @AuthenticationPrincipal CustomUserPrincipal principal
+    ) {
+        PaymentQueryUseCase.PaymentPreview preview =
+                paymentQueryUseCase.getCartPreview(principal.getId());
 
-    @Operation(summary = "결제 내역 조회", description = "로그인한 사용자의 결제 내역을 조회합니다.")
+        return ResponseEntity.ok(PaymentPreviewResponse.from(preview));
+    }
+
+    @Operation(
+            summary = "강의 결제",
+            description = """
+                    단일 강의 또는 장바구니에서 선택한 강의를 크레딧으로 결제합니다.
+                    COURSE 결제는 courseId가 필수이고,
+                    CART 결제는 courseId를 전달하지 않아야 합니다.
+                    """
+    )
+    @ApiResponses({
+            @ApiResponse(
+                    responseCode = "201",
+                    description = "결제 성공",
+                    content = @Content(schema = @Schema(implementation = PaymentResponse.class))
+            ),
+            @ApiResponse(
+                    responseCode = "400",
+                    description = "결제 요청 오류, 선택 강의 없음, 결제 동의 누락, 크레딧 부족 또는 구매 불가능한 강의",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+            ),
+            @ApiResponse(
+                    responseCode = "401",
+                    description = "인증 실패",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+            ),
+            @ApiResponse(
+                    responseCode = "404",
+                    description = "강의를 찾을 수 없음",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+            ),
+            @ApiResponse(
+                    responseCode = "409",
+                    description = "이미 수강 중인 강의",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+            )
+    })
+    @PostMapping("/checkout")
+    public ResponseEntity<PaymentResponse> checkout(
+            @AuthenticationPrincipal CustomUserPrincipal principal,
+            @RequestBody @Valid PaymentCheckoutRequest request
+    ) {
+        PaymentCommandUseCase.PaymentResult result =
+                paymentCommandUseCase.checkout(
+                        new PaymentCheckoutCommand(
+                                principal.getId(),
+                                request.purchaseType(),
+                                request.courseId(),
+                                request.agreed()
+                        )
+                );
+
+        return ResponseEntity
+                .status(HttpStatus.CREATED)
+                .body(PaymentResponse.from(result));
+    }
+
+    @Operation(
+            summary = "사용자 결제 내역 조회",
+            description = "로그인한 사용자의 강의 결제 내역을 최신순으로 조회합니다."
+    )
     @ApiResponses({
             @ApiResponse(
                     responseCode = "200",
@@ -129,8 +192,9 @@ public class PaymentController {
     public ResponseEntity<PaymentHistoryResponse> getPaymentHistory(
             @AuthenticationPrincipal CustomUserPrincipal principal
     ) {
-        return ResponseEntity.ok(
-                PaymentHistoryResponse.from(paymentQueryUseCase.getPaymentHistory(principal.getId()))
-        );
+        PaymentQueryUseCase.PaymentHistory history =
+                paymentQueryUseCase.getPaymentHistory(principal.getId());
+
+        return ResponseEntity.ok(PaymentHistoryResponse.from(history));
     }
 }

--- a/src/main/java/com/sashimi/payment/presentation/api/request.http
+++ b/src/main/java/com/sashimi/payment/presentation/api/request.http
@@ -1,15 +1,39 @@
 @baseUrl = http://localhost:8080
-@accessToken = 여기에_로그인_후_받은_accessToken_붙여넣기
+@accessToken = 로그인 후 발급받은 accessToken
+
+### 단일 강의 결제 전 조회
+GET {{baseUrl}}/payments/course/1/preview
+Accept: application/json
+Authorization: Bearer {{accessToken}}
+
+### 장바구니 선택 강의 결제 전 조회
+GET {{baseUrl}}/payments/cart/preview
+Accept: application/json
+Authorization: Bearer {{accessToken}}
+
+### 단일 강의 결제
+POST {{baseUrl}}/payments/checkout
+Content-Type: application/json
+Accept: application/json
+Authorization: Bearer {{accessToken}}
+
+{
+  "purchaseType": "COURSE",
+  "courseId": 1,
+  "agreed": true
+}
 
 ### 장바구니 선택 강의 결제
-POST {{baseUrl}}/payments/cart/checkout
+POST {{baseUrl}}/payments/checkout
+Content-Type: application/json
 Accept: application/json
 Authorization: Bearer {{accessToken}}
 
-### 단일 강의 바로 결제
-POST {{baseUrl}}/payments/course/1
-Accept: application/json
-Authorization: Bearer {{accessToken}}
+{
+  "purchaseType": "CART",
+  "courseId": null,
+  "agreed": true
+}
 
 ### 결제 내역 조회
 GET {{baseUrl}}/payments/history

--- a/src/main/java/com/sashimi/payment/presentation/api/request/PaymentCheckoutRequest.java
+++ b/src/main/java/com/sashimi/payment/presentation/api/request/PaymentCheckoutRequest.java
@@ -1,0 +1,35 @@
+package com.sashimi.payment.presentation.api.request;
+
+import com.sashimi.payment.application.command.PaymentPurchaseType;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.AssertTrue;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+
+public record PaymentCheckoutRequest(
+
+        @Schema(
+                description = "구매 유형",
+                example = "COURSE",
+                allowableValues = {"COURSE", "CART"}
+        )
+        @NotNull(message = "구매 유형은 필수입니다.")
+        PaymentPurchaseType purchaseType,
+
+        @Schema(
+                description = "단일 구매할 강의 ID. COURSE일 때 필수이며 CART일 때는 전달하지 않습니다.",
+                example = "10",
+                nullable = true
+        )
+        @Positive(message = "강의 ID는 양수여야 합니다.")
+        Long courseId,
+
+        @Schema(
+                description = "결제 약관 동의 여부. 반드시 true여야 합니다.",
+                example = "true"
+        )
+        @NotNull(message = "결제 동의 여부는 필수입니다.")
+        @AssertTrue(message = "결제 진행을 위해 결제 동의가 필요합니다.")
+        Boolean agreed
+) {
+}

--- a/src/main/java/com/sashimi/payment/presentation/api/response/PaymentHistoryCourseResponse.java
+++ b/src/main/java/com/sashimi/payment/presentation/api/response/PaymentHistoryCourseResponse.java
@@ -1,0 +1,26 @@
+package com.sashimi.payment.presentation.api.response;
+
+import com.sashimi.payment.application.usecase.PaymentQueryUseCase;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record PaymentHistoryCourseResponse(
+
+        @Schema(description = "강의 ID", example = "10")
+        Long courseId,
+
+        @Schema(description = "결제 당시 강의명", example = "React 완벽 가이드")
+        String title,
+
+        @Schema(description = "결제 당시 가격", example = "15900")
+        Long price
+) {
+    public static PaymentHistoryCourseResponse from(
+            PaymentQueryUseCase.PaymentHistoryCourse course
+    ) {
+        return new PaymentHistoryCourseResponse(
+                course.courseId(),
+                course.title(),
+                course.price()
+        );
+    }
+}

--- a/src/main/java/com/sashimi/payment/presentation/api/response/PaymentHistoryItemResponse.java
+++ b/src/main/java/com/sashimi/payment/presentation/api/response/PaymentHistoryItemResponse.java
@@ -1,8 +1,10 @@
 package com.sashimi.payment.presentation.api.response;
 
 import com.sashimi.payment.application.usecase.PaymentQueryUseCase;
+import io.swagger.v3.oas.annotations.media.Schema;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 public record PaymentHistoryItemResponse(
         Long paymentId,
@@ -12,9 +14,14 @@ public record PaymentHistoryItemResponse(
         String paymentStatus,
         String orderStatus,
         LocalDateTime paidAt,
-        LocalDateTime createdAt
+        LocalDateTime createdAt,
+
+        @Schema(description = "결제에 포함된 강의 목록")
+        List<PaymentHistoryCourseResponse> courses
 ) {
-    public static PaymentHistoryItemResponse from(PaymentQueryUseCase.PaymentHistoryItem item) {
+    public static PaymentHistoryItemResponse from(
+            PaymentQueryUseCase.PaymentHistoryItem item
+    ) {
         return new PaymentHistoryItemResponse(
                 item.paymentId(),
                 item.orderId(),
@@ -23,7 +30,10 @@ public record PaymentHistoryItemResponse(
                 item.paymentStatus(),
                 item.orderStatus(),
                 item.paidAt(),
-                item.createdAt()
+                item.createdAt(),
+                item.courses().stream()
+                        .map(PaymentHistoryCourseResponse::from)
+                        .toList()
         );
     }
 }

--- a/src/main/java/com/sashimi/payment/presentation/api/response/PaymentPreviewCourseResponse.java
+++ b/src/main/java/com/sashimi/payment/presentation/api/response/PaymentPreviewCourseResponse.java
@@ -1,0 +1,34 @@
+package com.sashimi.payment.presentation.api.response;
+
+import com.sashimi.payment.application.usecase.PaymentQueryUseCase;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record PaymentPreviewCourseResponse(
+
+        @Schema(description = "강의 ID", example = "10")
+        Long courseId,
+
+        @Schema(description = "강의명", example = "React 완벽 가이드")
+        String title,
+
+        @Schema(description = "강의 썸네일 주소", example = "/images/react.png")
+        String thumbnail,
+
+        @Schema(description = "강사명", example = "김강사")
+        String instructorName,
+
+        @Schema(description = "강의 가격", example = "15900")
+        Long price
+) {
+    public static PaymentPreviewCourseResponse from(
+            PaymentQueryUseCase.PaymentPreviewCourse course
+    ) {
+        return new PaymentPreviewCourseResponse(
+                course.courseId(),
+                course.title(),
+                course.thumbnail(),
+                course.instructorName(),
+                course.price()
+        );
+    }
+}

--- a/src/main/java/com/sashimi/payment/presentation/api/response/PaymentPreviewResponse.java
+++ b/src/main/java/com/sashimi/payment/presentation/api/response/PaymentPreviewResponse.java
@@ -1,0 +1,46 @@
+package com.sashimi.payment.presentation.api.response;
+
+import com.sashimi.payment.application.usecase.PaymentQueryUseCase;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.util.List;
+
+public record PaymentPreviewResponse(
+
+        @Schema(description = "구매 유형", example = "CART")
+        String purchaseType,
+
+        @Schema(description = "결제할 강의 목록")
+        List<PaymentPreviewCourseResponse> courses,
+
+        @Schema(description = "총 결제 금액", example = "34800")
+        Long totalAmount,
+
+        @Schema(description = "현재 보유 크레딧", example = "50000")
+        Long creditBalance,
+
+        @Schema(description = "결제 후 예상 잔액", example = "15200")
+        Long balanceAfterPayment,
+
+        @Schema(description = "부족한 크레딧 금액", example = "0")
+        Long insufficientAmount,
+
+        @Schema(description = "결제 가능 여부", example = "true")
+        boolean payable
+) {
+    public static PaymentPreviewResponse from(
+            PaymentQueryUseCase.PaymentPreview preview
+    ) {
+        return new PaymentPreviewResponse(
+                preview.purchaseType(),
+                preview.courses().stream()
+                        .map(PaymentPreviewCourseResponse::from)
+                        .toList(),
+                preview.totalAmount(),
+                preview.creditBalance(),
+                preview.balanceAfterPayment(),
+                preview.insufficientAmount(),
+                preview.payable()
+        );
+    }
+}

--- a/src/test/java/com/sashimi/payment/application/service/PaymentCommandServiceTest.java
+++ b/src/test/java/com/sashimi/payment/application/service/PaymentCommandServiceTest.java
@@ -1,6 +1,5 @@
 package com.sashimi.payment.application.service;
 
-import com.sashimi.order.application.policy.CoursePurchasePolicy;
 import com.sashimi.cart.application.port.CourseInfo;
 import com.sashimi.cart.domain.model.CartItem;
 import com.sashimi.cart.domain.repository.CartItemRepository;
@@ -9,14 +8,16 @@ import com.sashimi.credit.application.usecase.CreditCommandUseCase;
 import com.sashimi.enrollment.application.port.EnrollmentPort;
 import com.sashimi.global.exception.BusinessException;
 import com.sashimi.global.exception.ErrorCode;
-import com.sashimi.order.domain.model.OrderStatus;
-import com.sashimi.payment.application.command.CheckoutCartCommand;
-import com.sashimi.payment.application.command.PayCourseCommand;
+import com.sashimi.order.application.policy.CoursePurchasePolicy;
 import com.sashimi.order.domain.model.Order;
 import com.sashimi.order.domain.model.OrderItem;
-import com.sashimi.payment.domain.model.Payment;
+import com.sashimi.order.domain.model.OrderStatus;
 import com.sashimi.order.domain.repository.OrderItemRepository;
 import com.sashimi.order.domain.repository.OrderRepository;
+import com.sashimi.payment.application.command.PaymentCheckoutCommand;
+import com.sashimi.payment.application.command.PaymentPurchaseType;
+import com.sashimi.payment.domain.model.Payment;
+import com.sashimi.payment.domain.model.PaymentStatus;
 import com.sashimi.payment.domain.repository.PaymentRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -27,9 +28,18 @@ import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.catchThrowableOfType;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.*;
 
 class PaymentCommandServiceTest {
+
+    private static final Long USER_ID = 1L;
+    private static final Long COURSE_ID = 100L;
+    private static final Long COURSE_PRICE = 30_000L;
+    private static final Long ORDER_ID = 1L;
+    private static final Long ORDER_ITEM_ID = 11L;
+    private static final Long PAYMENT_ID = 20L;
 
     private CartItemRepository cartItemRepository;
     private CoursePurchasePolicy coursePurchasePolicy;
@@ -63,59 +73,16 @@ class PaymentCommandServiceTest {
     }
 
     @Test
-    void 장바구니_선택_강의를_결제하면_크레딧을_차감하고_수강등록_후_선택항목_삭제() {
-        CartItem cartItem = CartItem.restore(
-                10L,
-                1L,
-                100L,
-                30000L,
-                true,
-                LocalDateTime.now()
-        );
+    void 장바구니에서_선택한_강의를_결제하면_크레딧을_차감하고_수강_등록한_뒤_선택_항목을_삭제한다() {
+        CartItem cartItem = createCartItem();
+        CourseInfo courseInfo = createCourseInfo();
+        Order savedOrder = createSavedOrder();
+        OrderItem savedOrderItem = createSavedOrderItem();
+        Payment savedPayment = createSavedPayment();
 
-        CourseInfo courseInfo = new CourseInfo(
-                100L,
-                "Spring Boot Basic",
-                30000L,
-                "thumbnail.png",
-                "Instructor",
-                true
-        );
-
-        Order savedOrder = Order.restore(
-                1L,
-                "ORD-TEST",
-                30000L,
-                0L,
-                30000L,
-                OrderStatus.PAID,
-                LocalDateTime.now(),
-                1L
-        );
-
-        OrderItem savedOrderItem = OrderItem.restore(
-                11L,
-                "Spring Boot Basic",
-                30000L,
-                0L,
-                30000L,
-                1L,
-                100L
-        );
-
-        Payment savedPayment = Payment.restore(
-                20L,
-                30000L,
-                com.sashimi.payment.domain.model.PaymentStatus.PAID,
-                LocalDateTime.now(),
-                LocalDateTime.now(),
-                1L,
-                1L
-        );
-
-        when(cartItemRepository.findAllSelectedByUserId(1L))
+        when(cartItemRepository.findAllSelectedByUserId(USER_ID))
                 .thenReturn(List.of(cartItem));
-        when(coursePurchasePolicy.validatePurchasable(1L, 100L))
+        when(coursePurchasePolicy.validatePurchasable(USER_ID, COURSE_ID))
                 .thenReturn(courseInfo);
         when(orderRepository.save(any(Order.class)))
                 .thenReturn(savedOrder);
@@ -124,69 +91,53 @@ class PaymentCommandServiceTest {
         when(paymentRepository.save(any(Payment.class)))
                 .thenReturn(savedPayment);
 
-        var result = paymentCommandService.checkoutCart(new CheckoutCartCommand(1L));
+        var result = paymentCommandService.checkout(
+                new PaymentCheckoutCommand(
+                        USER_ID,
+                        PaymentPurchaseType.CART,
+                        null,
+                        true
+                )
+        );
 
-        assertThat(result.orderId()).isEqualTo(1L);
-        assertThat(result.paymentId()).isEqualTo(20L);
-        assertThat(result.amount()).isEqualTo(30000L);
+        assertThat(result.orderId()).isEqualTo(ORDER_ID);
+        assertThat(result.orderNo()).isEqualTo("ORD-TEST");
+        assertThat(result.paymentId()).isEqualTo(PAYMENT_ID);
+        assertThat(result.amount()).isEqualTo(COURSE_PRICE);
+        assertThat(result.status()).isEqualTo("PAID");
         assertThat(result.courses()).hasSize(1);
-        assertThat(result.courses().get(0).courseId()).isEqualTo(100L);
+        assertThat(result.courses().get(0).courseId())
+                .isEqualTo(COURSE_ID);
+        assertThat(result.courses().get(0).title())
+                .isEqualTo("Spring Boot Basic");
+        assertThat(result.courses().get(0).price())
+                .isEqualTo(COURSE_PRICE);
 
         ArgumentCaptor<UseCreditCommand> creditCaptor =
                 ArgumentCaptor.forClass(UseCreditCommand.class);
 
         verify(creditCommandUseCase).useCredit(creditCaptor.capture());
-        assertThat(creditCaptor.getValue().userId()).isEqualTo(1L);
-        assertThat(creditCaptor.getValue().amount()).isEqualTo(30000L);
+        assertThat(creditCaptor.getValue().userId()).isEqualTo(USER_ID);
+        assertThat(creditCaptor.getValue().amount()).isEqualTo(COURSE_PRICE);
 
-        verify(enrollmentPort).enrollPaidCourse(1L, 100L, 11L);
-        verify(cartItemRepository).deleteAllSelectedByUserId(1L);
-        verify(cartItemRepository, never()).deleteByUserIdAndCourseId(anyLong(), anyLong());
+        verify(coursePurchasePolicy)
+                .validatePurchasable(USER_ID, COURSE_ID);
+        verify(enrollmentPort)
+                .enrollPaidCourse(USER_ID, COURSE_ID, ORDER_ITEM_ID);
+        verify(cartItemRepository)
+                .deleteAllSelectedByUserId(USER_ID);
+        verify(cartItemRepository, never())
+                .deleteByUserIdAndCourseId(anyLong(), anyLong());
     }
 
     @Test
-    void 단일_강의를_바로_결제_시_수강등록_후_같은_강의_장바구니_항목_삭제() {
-        CourseInfo courseInfo = new CourseInfo(
-                100L,
-                "Spring Boot Basic",
-                30000L,
-                "thumbnail.png",
-                "Instructor",
-                true
-        );
+    void 단일_강의를_결제하면_크레딧을_차감하고_수강_등록한_뒤_같은_강의를_장바구니에서_삭제한다() {
+        CourseInfo courseInfo = createCourseInfo();
+        Order savedOrder = createSavedOrder();
+        OrderItem savedOrderItem = createSavedOrderItem();
+        Payment savedPayment = createSavedPayment();
 
-        Order savedOrder = Order.restore(
-                1L,
-                "ORD-TEST",
-                30000L,
-                0L,
-                30000L,
-                OrderStatus.PAID,
-                LocalDateTime.now(),
-                1L
-        );
-
-        OrderItem savedOrderItem = OrderItem.restore(
-                11L,
-                "Spring Boot Basic",
-                30000L,
-                0L,
-                30000L,
-                1L,
-                100L
-        );
-
-        Payment savedPayment = Payment.restore(
-                20L,
-                30000L,
-                com.sashimi.payment.domain.model.PaymentStatus.PAID,
-                LocalDateTime.now(),
-                LocalDateTime.now(),
-                1L,
-                1L
-        );
-
-        when(coursePurchasePolicy.validatePurchasable(1L, 100L))
+        when(coursePurchasePolicy.validatePurchasable(USER_ID, COURSE_ID))
                 .thenReturn(courseInfo);
         when(orderRepository.save(any(Order.class)))
                 .thenReturn(savedOrder);
@@ -195,30 +146,137 @@ class PaymentCommandServiceTest {
         when(paymentRepository.save(any(Payment.class)))
                 .thenReturn(savedPayment);
 
-        var result = paymentCommandService.payCourse(new PayCourseCommand(1L, 100L));
+        var result = paymentCommandService.checkout(
+                new PaymentCheckoutCommand(
+                        USER_ID,
+                        PaymentPurchaseType.COURSE,
+                        COURSE_ID,
+                        true
+                )
+        );
 
-        assertThat(result.orderId()).isEqualTo(1L);
-        assertThat(result.paymentId()).isEqualTo(20L);
+        assertThat(result.orderId()).isEqualTo(ORDER_ID);
+        assertThat(result.orderNo()).isEqualTo("ORD-TEST");
+        assertThat(result.paymentId()).isEqualTo(PAYMENT_ID);
+        assertThat(result.amount()).isEqualTo(COURSE_PRICE);
+        assertThat(result.status()).isEqualTo("PAID");
         assertThat(result.courses()).hasSize(1);
+        assertThat(result.courses().get(0).courseId())
+                .isEqualTo(COURSE_ID);
 
-        verify(creditCommandUseCase).useCredit(any(UseCreditCommand.class));
-        verify(enrollmentPort).enrollPaidCourse(1L, 100L, 11L);
-        verify(cartItemRepository).deleteByUserIdAndCourseId(1L, 100L);
-        verify(cartItemRepository, never()).deleteAllSelectedByUserId(anyLong());
+        ArgumentCaptor<UseCreditCommand> creditCaptor =
+                ArgumentCaptor.forClass(UseCreditCommand.class);
+
+        verify(creditCommandUseCase).useCredit(creditCaptor.capture());
+        assertThat(creditCaptor.getValue().userId()).isEqualTo(USER_ID);
+        assertThat(creditCaptor.getValue().amount()).isEqualTo(COURSE_PRICE);
+
+        verify(coursePurchasePolicy)
+                .validatePurchasable(USER_ID, COURSE_ID);
+        verify(enrollmentPort)
+                .enrollPaidCourse(USER_ID, COURSE_ID, ORDER_ITEM_ID);
+        verify(cartItemRepository)
+                .deleteByUserIdAndCourseId(USER_ID, COURSE_ID);
+        verify(cartItemRepository, never())
+                .deleteAllSelectedByUserId(anyLong());
     }
 
     @Test
-    void 선택된_장바구니_항목이_없으면_결제_진행_X() {
-        when(cartItemRepository.findAllSelectedByUserId(1L))
+    void 선택한_장바구니_항목이_없으면_결제를_진행하지_않는다() {
+        when(cartItemRepository.findAllSelectedByUserId(USER_ID))
                 .thenReturn(List.of());
 
         BusinessException exception = catchThrowableOfType(
-                () -> paymentCommandService.checkoutCart(new CheckoutCartCommand(1L)),
+                () -> paymentCommandService.checkout(
+                        new PaymentCheckoutCommand(
+                                USER_ID,
+                                PaymentPurchaseType.CART,
+                                null,
+                                true
+                        )
+                ),
                 BusinessException.class
         );
 
-        assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.CART_EMPTY_SELECTION);
+        assertThat(exception.getErrorCode())
+                .isEqualTo(ErrorCode.CART_EMPTY_SELECTION);
 
+        verify(cartItemRepository)
+                .findAllSelectedByUserId(USER_ID);
+        verifyNoInteractions(coursePurchasePolicy);
+        verifyNoInteractions(orderRepository);
+        verifyNoInteractions(orderItemRepository);
+        verifyNoInteractions(paymentRepository);
+        verifyNoInteractions(creditCommandUseCase);
+        verifyNoInteractions(enrollmentPort);
+
+        verify(cartItemRepository, never())
+                .deleteAllSelectedByUserId(anyLong());
+    }
+
+    @Test
+    void 크레딧이_부족하면_수강_등록과_장바구니_삭제를_진행하지_않는다() {
+        CourseInfo courseInfo = createCourseInfo();
+        Order savedOrder = createSavedOrder();
+        OrderItem savedOrderItem = createSavedOrderItem();
+        Payment savedPayment = createSavedPayment();
+
+        when(coursePurchasePolicy.validatePurchasable(USER_ID, COURSE_ID))
+                .thenReturn(courseInfo);
+        when(orderRepository.save(any(Order.class)))
+                .thenReturn(savedOrder);
+        when(orderItemRepository.save(any(OrderItem.class)))
+                .thenReturn(savedOrderItem);
+        when(paymentRepository.save(any(Payment.class)))
+                .thenReturn(savedPayment);
+
+        doThrow(new BusinessException(ErrorCode.CREDIT_INSUFFICIENT_BALANCE))
+                .when(creditCommandUseCase)
+                .useCredit(any(UseCreditCommand.class));
+
+        BusinessException exception = catchThrowableOfType(
+                () -> paymentCommandService.checkout(
+                        new PaymentCheckoutCommand(
+                                USER_ID,
+                                PaymentPurchaseType.COURSE,
+                                COURSE_ID,
+                                true
+                        )
+                ),
+                BusinessException.class
+        );
+
+        assertThat(exception.getErrorCode())
+                .isEqualTo(ErrorCode.CREDIT_INSUFFICIENT_BALANCE);
+
+        verify(creditCommandUseCase)
+                .useCredit(any(UseCreditCommand.class));
+        verify(enrollmentPort, never())
+                .enrollPaidCourse(anyLong(), anyLong(), anyLong());
+        verify(cartItemRepository, never())
+                .deleteByUserIdAndCourseId(anyLong(), anyLong());
+        verify(cartItemRepository, never())
+                .deleteAllSelectedByUserId(anyLong());
+    }
+
+    @Test
+    void 결제에_동의하지_않으면_결제를_진행하지_않는다() {
+        BusinessException exception = catchThrowableOfType(
+                () -> paymentCommandService.checkout(
+                        new PaymentCheckoutCommand(
+                                USER_ID,
+                                PaymentPurchaseType.COURSE,
+                                COURSE_ID,
+                                false
+                        )
+                ),
+                BusinessException.class
+        );
+
+        assertThat(exception.getErrorCode())
+                .isEqualTo(ErrorCode.PAYMENT_AGREEMENT_REQUIRED);
+
+        verifyNoInteractions(cartItemRepository);
         verifyNoInteractions(coursePurchasePolicy);
         verifyNoInteractions(orderRepository);
         verifyNoInteractions(orderItemRepository);
@@ -228,68 +286,165 @@ class PaymentCommandServiceTest {
     }
 
     @Test
-    void 크레딧이_부족하면_수강등록과_장바구니_삭제_X() {
-        CourseInfo courseInfo = new CourseInfo(
-                100L,
+    void 구매_유형이_없으면_결제를_진행하지_않는다() {
+        BusinessException exception = catchThrowableOfType(
+                () -> paymentCommandService.checkout(
+                        new PaymentCheckoutCommand(
+                                USER_ID,
+                                null,
+                                COURSE_ID,
+                                true
+                        )
+                ),
+                BusinessException.class
+        );
+
+        assertThat(exception.getErrorCode())
+                .isEqualTo(ErrorCode.PAYMENT_INVALID_CHECKOUT_REQUEST);
+
+        verifyNoInteractions(cartItemRepository);
+        verifyNoInteractions(coursePurchasePolicy);
+        verifyNoInteractions(orderRepository);
+        verifyNoInteractions(orderItemRepository);
+        verifyNoInteractions(paymentRepository);
+        verifyNoInteractions(creditCommandUseCase);
+        verifyNoInteractions(enrollmentPort);
+    }
+
+    @Test
+    void 단일_강의_결제에는_courseId가_필요하다() {
+        BusinessException exception = catchThrowableOfType(
+                () -> paymentCommandService.checkout(
+                        new PaymentCheckoutCommand(
+                                USER_ID,
+                                PaymentPurchaseType.COURSE,
+                                null,
+                                true
+                        )
+                ),
+                BusinessException.class
+        );
+
+        assertThat(exception.getErrorCode())
+                .isEqualTo(ErrorCode.PAYMENT_COURSE_ID_REQUIRED);
+
+        verifyNoInteractions(cartItemRepository);
+        verifyNoInteractions(coursePurchasePolicy);
+        verifyNoInteractions(orderRepository);
+        verifyNoInteractions(orderItemRepository);
+        verifyNoInteractions(paymentRepository);
+        verifyNoInteractions(creditCommandUseCase);
+        verifyNoInteractions(enrollmentPort);
+    }
+
+    @Test
+    void 단일_강의_결제의_courseId가_양수가_아니면_결제할_수_없다() {
+        BusinessException exception = catchThrowableOfType(
+                () -> paymentCommandService.checkout(
+                        new PaymentCheckoutCommand(
+                                USER_ID,
+                                PaymentPurchaseType.COURSE,
+                                0L,
+                                true
+                        )
+                ),
+                BusinessException.class
+        );
+
+        assertThat(exception.getErrorCode())
+                .isEqualTo(ErrorCode.PAYMENT_COURSE_ID_REQUIRED);
+
+        verifyNoInteractions(cartItemRepository);
+        verifyNoInteractions(coursePurchasePolicy);
+        verifyNoInteractions(orderRepository);
+        verifyNoInteractions(orderItemRepository);
+        verifyNoInteractions(paymentRepository);
+        verifyNoInteractions(creditCommandUseCase);
+        verifyNoInteractions(enrollmentPort);
+    }
+
+    @Test
+    void 장바구니_결제에는_courseId를_전달할_수_없다() {
+        BusinessException exception = catchThrowableOfType(
+                () -> paymentCommandService.checkout(
+                        new PaymentCheckoutCommand(
+                                USER_ID,
+                                PaymentPurchaseType.CART,
+                                COURSE_ID,
+                                true
+                        )
+                ),
+                BusinessException.class
+        );
+
+        assertThat(exception.getErrorCode())
+                .isEqualTo(ErrorCode.PAYMENT_CART_COURSE_ID_NOT_ALLOWED);
+
+        verifyNoInteractions(cartItemRepository);
+        verifyNoInteractions(coursePurchasePolicy);
+        verifyNoInteractions(orderRepository);
+        verifyNoInteractions(orderItemRepository);
+        verifyNoInteractions(paymentRepository);
+        verifyNoInteractions(creditCommandUseCase);
+        verifyNoInteractions(enrollmentPort);
+    }
+
+    private CartItem createCartItem() {
+        return CartItem.restore(
+                10L,
+                USER_ID,
+                COURSE_ID,
+                COURSE_PRICE,
+                true,
+                LocalDateTime.now()
+        );
+    }
+
+    private CourseInfo createCourseInfo() {
+        return new CourseInfo(
+                COURSE_ID,
                 "Spring Boot Basic",
-                30000L,
+                COURSE_PRICE,
                 "thumbnail.png",
                 "Instructor",
                 true
         );
+    }
 
-        Order savedOrder = Order.restore(
-                1L,
+    private Order createSavedOrder() {
+        return Order.restore(
+                ORDER_ID,
                 "ORD-TEST",
-                30000L,
+                COURSE_PRICE,
                 0L,
-                30000L,
+                COURSE_PRICE,
                 OrderStatus.PAID,
                 LocalDateTime.now(),
-                1L
+                USER_ID
         );
+    }
 
-        OrderItem savedOrderItem = OrderItem.restore(
-                11L,
+    private OrderItem createSavedOrderItem() {
+        return OrderItem.restore(
+                ORDER_ITEM_ID,
                 "Spring Boot Basic",
-                30000L,
+                COURSE_PRICE,
                 0L,
-                30000L,
-                1L,
-                100L
+                COURSE_PRICE,
+                ORDER_ID,
+                COURSE_ID
         );
+    }
 
-        Payment savedPayment = Payment.restore(
-                20L,
-                30000L,
-                com.sashimi.payment.domain.model.PaymentStatus.PAID,
+    private Payment createSavedPayment() {
+        return Payment.restore(
+                PAYMENT_ID,
+                COURSE_PRICE,
+                PaymentStatus.PAID,
                 LocalDateTime.now(),
                 LocalDateTime.now(),
-                1L,
-                1L
+                ORDER_ID,
+                USER_ID
         );
-
-        when(coursePurchasePolicy.validatePurchasable(1L, 100L))
-                .thenReturn(courseInfo);
-        when(orderRepository.save(any(Order.class)))
-                .thenReturn(savedOrder);
-        when(orderItemRepository.save(any(OrderItem.class)))
-                .thenReturn(savedOrderItem);
-        when(paymentRepository.save(any(Payment.class)))
-                .thenReturn(savedPayment);
-        doThrow(new BusinessException(ErrorCode.CREDIT_INSUFFICIENT_BALANCE))
-                .when(creditCommandUseCase)
-                .useCredit(any(UseCreditCommand.class));
-
-        BusinessException exception = catchThrowableOfType(
-                () -> paymentCommandService.payCourse(new PayCourseCommand(1L, 100L)),
-                BusinessException.class
-        );
-
-        assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.CREDIT_INSUFFICIENT_BALANCE);
-
-        verify(enrollmentPort, never()).enrollPaidCourse(anyLong(), anyLong(), anyLong());
-        verify(cartItemRepository, never()).deleteByUserIdAndCourseId(anyLong(), anyLong());
-        verify(cartItemRepository, never()).deleteAllSelectedByUserId(anyLong());
     }
 }


### PR DESCRIPTION
## 📌 PR 요약
- 단일 강의 결제 및 장바구니 결제 조회 기능을 분할하고 최종 결제 시 api는 1개로 통일 진행
- Toss Payments 테스트 받아서 환경 변수 세팅 완료(슬랙에 방법 공유 완료)
---

## 🛠️ 작업 상세 내용 (체크로 선택)
- [ ] ✨ FEATURE
- [ ] 🔧 UPDATE
- [ ] 🐛 BUGFIX
- [ ] ♻️ REFACTOR
- [ ] 📝 DOCS

---

## 📋 작업 상세 내용
<img width="2030" height="168" alt="image" src="https://github.com/user-attachments/assets/c95b6626-3654-48c8-b974-6ec3ac30fcfb" />


---

## 🔗 PR 관련 이슈로 닫기
Closes #244 
Closes #229 

---

## ✅ 체크리스트 (확인 절차)
- [ ] 정상적으로 빌드 및 실행됩니다.
- [ ] 주요 기능이 정상 동작합니다.
- [ ] 불필요한 코드를 제거했습니다.
- [ ] 코드 리뷰 준비가 완료되었습니다.

---

## 💬 리뷰어에게 할 말
- 

---

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 단일 강의 및 장바구니 결제 전 금액 미리보기 기능 추가
  * 통합 결제 엔드포인트 구현으로 간편한 결제 프로세스 제공

* **Bug Fixes**
  * 결제 요청 검증 오류 처리 강화

* **Documentation**
  * 결제 관련 API 문서화 및 응답 코드 설명 개선
  * 신규 에러 코드 추가로 결제 오류 처리 명확화

<!-- end of auto-generated comment: release notes by coderabbit.ai -->