### PR TITLE
[UPDATE] #249 NCS 공공데이터 동기화 및 강의 상세 NCS 응답 개선

### DIFF
--- a/src/main/java/com/sashimi/LmsApplication.java
+++ b/src/main/java/com/sashimi/LmsApplication.java
@@ -1,12 +1,15 @@
 package com.sashimi;
 
+import com.sashimi.ncs.infrastructure.publicdata.NcsApiProperties;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.scheduling.annotation.EnableAsync;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
 @EnableAsync
 @EnableScheduling
+@EnableConfigurationProperties(NcsApiProperties.class)
 @SpringBootApplication
 public class LmsApplication {
 

--- a/src/main/java/com/sashimi/category/domain/model/Category.java
+++ b/src/main/java/com/sashimi/category/domain/model/Category.java
@@ -6,16 +6,18 @@ public class Category {
 
     private final Long id;
     private final Long mainCategoryId;
+    private final Long ncsInfoId;
     private final String name;
     private final String subCategory;
     private final int sortOrder;
     private final boolean active;
     private final LocalDateTime createdAt;
 
-    private Category(Long id, Long mainCategoryId, String name, String subCategory,
+    private Category(Long id, Long mainCategoryId, Long ncsInfoId, String name, String subCategory,
                      int sortOrder, boolean active, LocalDateTime createdAt) {
         this.id = id;
         this.mainCategoryId = mainCategoryId;
+        this.ncsInfoId = ncsInfoId;
         this.name = name;
         this.subCategory = subCategory;
         this.sortOrder = sortOrder;
@@ -23,13 +25,16 @@ public class Category {
         this.createdAt = createdAt;
     }
 
-    public static Category restore(Long id, Long mainCategoryId, String name, String subCategory,
+    public static Category restore(Long id, Long mainCategoryId, Long ncsInfoId,
+                                   String name, String subCategory,
                                    int sortOrder, boolean active, LocalDateTime createdAt) {
-        return new Category(id, mainCategoryId, name, subCategory, sortOrder, active, createdAt);
+        return new Category(id, mainCategoryId, ncsInfoId, name, subCategory,
+                sortOrder, active, createdAt);
     }
 
     public Long getId() { return id; }
     public Long getMainCategoryId() { return mainCategoryId; }
+    public Long getNcsInfoId() { return ncsInfoId; }
     public String getName() { return name; }
     public String getSubCategory() { return subCategory; }
     public int getSortOrder() { return sortOrder; }

--- a/src/main/java/com/sashimi/category/infrastructure/persistence/CategoryJpaEntity.java
+++ b/src/main/java/com/sashimi/category/infrastructure/persistence/CategoryJpaEntity.java
@@ -32,9 +32,50 @@ public class CategoryJpaEntity {
     @Column(name = "created_at", nullable = false)
     private LocalDateTime createdAt;
 
+    @Column(name = "ncs_info_id")
+    private Long ncsInfoId;
+
     protected CategoryJpaEntity() {}
 
+    public void updateNcsInfoId(Long ncsInfoId) {
+        this.ncsInfoId = ncsInfoId;
+    }
+
+
     public Category toDomain() {
-        return Category.restore(id, mainCategoryId, name, subCategory, sortOrder, active, createdAt);
+        return Category.restore(id, mainCategoryId, ncsInfoId, name, subCategory,
+                sortOrder, active, createdAt);
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public Long getMainCategoryId() {
+        return mainCategoryId;
+    }
+
+    public Long getNcsInfoId() {
+        return ncsInfoId;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public String getSubCategory() {
+        return subCategory;
+    }
+
+    public int getSortOrder() {
+        return sortOrder;
+    }
+
+    public boolean isActive() {
+        return active;
+    }
+
+    public LocalDateTime getCreatedAt() {
+        return createdAt;
     }
 }

--- a/src/main/java/com/sashimi/course/application/command/CreateCourseCommand.java
+++ b/src/main/java/com/sashimi/course/application/command/CreateCourseCommand.java
@@ -13,7 +13,6 @@ public record CreateCourseCommand(
         Long price,
         CourseDifficulty difficulty,
         String thumbnail,
-        Long ncsInfoId,
         CourseStatus initialStatus,
         List<CreateSessionCommand> sessions
 ) {}

--- a/src/main/java/com/sashimi/course/application/command/UpdateCourseCommand.java
+++ b/src/main/java/com/sashimi/course/application/command/UpdateCourseCommand.java
@@ -14,7 +14,6 @@ public record UpdateCourseCommand(
         Long price,
         CourseDifficulty difficulty,
         String thumbnail,
-        Long ncsInfoId,
         CourseStatus targetStatus,
         List<CreateSessionCommand> sessions
 ) {}

--- a/src/main/java/com/sashimi/course/application/port/CategoryPort.java
+++ b/src/main/java/com/sashimi/course/application/port/CategoryPort.java
@@ -6,4 +6,5 @@ public interface CategoryPort {
     List<Long> getCategoryIdsByName(String categoryName);
     Long getCategoryIdBySubCategoryName(String subCategoryName);
     String getCategoryNameById(Long categoryId);
+    Long getNcsInfoIdByCategoryId(Long categoryId);
 }

--- a/src/main/java/com/sashimi/course/application/port/NcsInfoQueryPort.java
+++ b/src/main/java/com/sashimi/course/application/port/NcsInfoQueryPort.java
@@ -1,0 +1,7 @@
+package com.sashimi.course.application.port;
+
+import java.util.Optional;
+
+public interface NcsInfoQueryPort {
+    Optional<NcsInfoView> findViewByRepresentativeId(Long ncsInfoId);
+}

--- a/src/main/java/com/sashimi/course/application/port/NcsInfoView.java
+++ b/src/main/java/com/sashimi/course/application/port/NcsInfoView.java
@@ -1,0 +1,10 @@
+package com.sashimi.course.application.port;
+
+import java.util.List;
+
+public record NcsInfoView(
+        String categoryPath,
+        String jobDescription,
+        List<String> abilityUnitNames,
+        int totalAbilityUnitCount
+) {}

--- a/src/main/java/com/sashimi/course/application/query/PublicCourseDetailView.java
+++ b/src/main/java/com/sashimi/course/application/query/PublicCourseDetailView.java
@@ -1,6 +1,7 @@
 package com.sashimi.course.application.query;
 
 import com.sashimi.course.domain.model.CourseDifficulty;
+import com.sashimi.course.application.port.NcsInfoView;
 
 import java.math.BigDecimal;
 import java.util.List;
@@ -18,6 +19,7 @@ public record PublicCourseDetailView(
         int studentCount,
         String instructorName,
         String categoryName,
+        NcsInfoView ncs,
         List<SessionView> sessions
 ) {
     public record SessionView(

--- a/src/main/java/com/sashimi/course/application/service/CourseCommandService.java
+++ b/src/main/java/com/sashimi/course/application/service/CourseCommandService.java
@@ -27,6 +27,7 @@ public class CourseCommandService implements CourseCommandUseCase {
 
     @Override
     public Long createCourse(CreateCourseCommand command) {
+
         Long categoryId = categoryPort.getCategoryIdBySubCategoryName(command.subCategoryName());
 
         List<CourseSession> sessions = command.sessions().stream()
@@ -35,7 +36,7 @@ public class CourseCommandService implements CourseCommandUseCase {
                         s.attachmentUrl(), s.attachmentType(), s.attachmentSize()))
                 .toList();
 
-        Course course = Course.create(command.instructorId(), categoryId, command.ncsInfoId(),
+        Course course = Course.create(command.instructorId(), categoryId,
                 command.title(), command.description(), command.price(), command.difficulty(),
                 command.thumbnail(), command.initialStatus(), sessions);
 
@@ -55,13 +56,14 @@ public class CourseCommandService implements CourseCommandUseCase {
             throw new BusinessException(ErrorCode.COURSE_NOT_MODIFIABLE);
         }
 
+
         List<CourseSession> sessions = command.sessions().stream()
                 .map(s -> CourseSession.create(s.title(), s.videoUrl(), s.durationSeconds(),
                         s.sessionOrder(), s.preview(), s.attachmentName(),
                         s.attachmentUrl(), s.attachmentType(), s.attachmentSize()))
                 .toList();
 
-        Course updated = course.update(command.categoryId(), command.ncsInfoId(),
+        Course updated = course.update(command.categoryId(),
                 command.title(), command.description(), command.price(), command.difficulty(),
                 command.thumbnail(), command.targetStatus(), sessions);
 

--- a/src/main/java/com/sashimi/course/application/service/PublicCourseQueryService.java
+++ b/src/main/java/com/sashimi/course/application/service/PublicCourseQueryService.java
@@ -2,6 +2,8 @@ package com.sashimi.course.application.service;
 
 import com.sashimi.course.application.port.CategoryPort;
 import com.sashimi.course.application.port.InstructorPort;
+import com.sashimi.course.application.port.NcsInfoQueryPort;
+import com.sashimi.course.application.port.NcsInfoView;
 import com.sashimi.course.application.query.PublicCourseDetailView;
 import com.sashimi.course.application.query.PublicCourseView;
 import com.sashimi.course.application.usecase.PublicCourseQueryUseCase;
@@ -26,13 +28,16 @@ public class PublicCourseQueryService implements PublicCourseQueryUseCase {
     private final CourseRepository courseRepository;
     private final CategoryPort categoryPort;
     private final InstructorPort instructorPort;
+    private final NcsInfoQueryPort ncsInfoQueryPort;
 
     public PublicCourseQueryService(CourseRepository courseRepository,
                                     CategoryPort categoryPort,
-                                    InstructorPort instructorPort) {
+                                    InstructorPort instructorPort,
+                                    NcsInfoQueryPort ncsInfoQueryPort) {
         this.courseRepository = courseRepository;
         this.categoryPort = categoryPort;
         this.instructorPort = instructorPort;
+        this.ncsInfoQueryPort = ncsInfoQueryPort;
     }
 
     @Override
@@ -67,6 +72,9 @@ public class PublicCourseQueryService implements PublicCourseQueryUseCase {
         String instructorName = instructorPort.getInstructorName(course.getInstructorId());
         String categoryName = categoryPort.getCategoryNameById(course.getCategoryId());
 
+        Long ncsInfoId = categoryPort.getNcsInfoIdByCategoryId(course.getCategoryId());
+        NcsInfoView ncs = ncsInfoId == null ? null : ncsInfoQueryPort.findViewByRepresentativeId(ncsInfoId).orElse(null);
+
         List<PublicCourseDetailView.SessionView> sessions = course.getSessions().stream()
                 .map(s -> new PublicCourseDetailView.SessionView(
                         s.getId(),
@@ -82,7 +90,7 @@ public class PublicCourseQueryService implements PublicCourseQueryUseCase {
                 course.getId(), course.getTitle(), course.getDescription(),
                 course.getPrice(), course.getDifficulty(), course.getThumbnail(),
                 course.getTotalDuration(), course.getRatingAvg(), course.getReviewCount(),
-                course.getStudentCount(), instructorName, categoryName, sessions
+                course.getStudentCount(), instructorName, categoryName, ncs, sessions
         );
     }
 

--- a/src/main/java/com/sashimi/course/domain/model/Course.java
+++ b/src/main/java/com/sashimi/course/domain/model/Course.java
@@ -9,7 +9,6 @@ public class Course {
     private final Long id;
     private final Long instructorId;
     private final Long categoryId;
-    private final Long ncsInfoId;
     private final String title;
     private final String description;
     private final Long price;
@@ -26,7 +25,7 @@ public class Course {
     private final LocalDateTime approvedAt;
     private final List<CourseSession> sessions;
 
-    private Course(Long id, Long instructorId, Long categoryId, Long ncsInfoId, String title, String description,
+    private Course(Long id, Long instructorId, Long categoryId, String title, String description,
                    Long price, CourseDifficulty difficulty, String thumbnail, int totalDuration,
                    CourseStatus status, String rejectReason, BigDecimal ratingAvg,
                    int reviewCount, int studentCount, LocalDateTime createdAt,
@@ -41,7 +40,6 @@ public class Course {
         this.id = id;
         this.instructorId = instructorId;
         this.categoryId = categoryId;
-        this.ncsInfoId = ncsInfoId;
         this.title = title;
         this.description = description;
         this.price = price;
@@ -58,36 +56,36 @@ public class Course {
         this.approvedAt = approvedAt;
         this.sessions = sessions != null ? sessions : List.of();
     }
-    public static Course create(Long instructorId, Long categoryId, Long ncsInfoId,
+    public static Course create(Long instructorId, Long categoryId,
                                 String title, String description, Long price,
                                 CourseDifficulty difficulty, String thumbnail,
                                 CourseStatus initialStatus, List<CourseSession> sessions) {
         validateWritableStatus(initialStatus);
         int totalDuration = sessions == null ? 0 : sessions.stream().mapToInt(CourseSession::getDurationSeconds).sum();
-        return new Course(null, instructorId, categoryId, ncsInfoId, title, description, price,
+        return new Course(null, instructorId, categoryId, title, description, price,
                 difficulty, thumbnail, totalDuration, initialStatus, null,
                 BigDecimal.ZERO, 0, 0, LocalDateTime.now(), null, null, sessions);
     }
 
-    public static Course restore(Long id, Long instructorId, Long categoryId, Long ncsInfoId,
+    public static Course restore(Long id, Long instructorId, Long categoryId,
                                  String title, String description, Long price,
                                  CourseDifficulty difficulty, String thumbnail, int totalDuration,
                                  CourseStatus status, String rejectReason, BigDecimal ratingAvg,
                                  int reviewCount, int studentCount, LocalDateTime createdAt,
                                  LocalDateTime updatedAt, LocalDateTime approvedAt,
                                  List<CourseSession> sessions) {
-        return new Course(id, instructorId, categoryId, ncsInfoId, title, description, price,
+        return new Course(id, instructorId, categoryId, title, description, price,
                 difficulty, thumbnail, totalDuration, status, rejectReason, ratingAvg,
                 reviewCount, studentCount, createdAt, updatedAt, approvedAt, sessions);
     }
 
-    public Course update(Long categoryId, Long ncsInfoId, String title, String description, Long price,
+    public Course update(Long categoryId, String title, String description, Long price,
                          CourseDifficulty difficulty, String thumbnail, CourseStatus targetStatus,
                          List<CourseSession> sessions) {
         if (!canModify()) throw new IllegalStateException("수정할 수 없는 상태의 강의입니다.");
         validateWritableStatus(targetStatus);
         int totalDuration = sessions == null ? 0 : sessions.stream().mapToInt(CourseSession::getDurationSeconds).sum();
-        return new Course(this.id, this.instructorId, categoryId, ncsInfoId, title, description,
+        return new Course(this.id, this.instructorId, categoryId, title, description,
                 price, difficulty, thumbnail, totalDuration, targetStatus, null,
                 this.ratingAvg, this.reviewCount, this.studentCount, this.createdAt,
                 LocalDateTime.now(), this.approvedAt, sessions);
@@ -95,7 +93,7 @@ public class Course {
 
     public Course approve() {
         if (this.status != CourseStatus.PENDING) throw new IllegalStateException("승인 대기 상태가 아닌 강의입니다.");
-        return new Course(id, instructorId, categoryId, ncsInfoId, title, description, price,
+        return new Course(id, instructorId, categoryId, title, description, price,
                 difficulty, thumbnail, totalDuration, CourseStatus.APPROVED, null,
                 ratingAvg, reviewCount, studentCount, createdAt, LocalDateTime.now(),
                 LocalDateTime.now(), sessions);
@@ -103,7 +101,7 @@ public class Course {
 
     public Course reject(String reason) {
         if (this.status != CourseStatus.PENDING) throw new IllegalStateException("승인 대기 상태가 아닌 강의입니다.");
-        return new Course(id, instructorId, categoryId, ncsInfoId, title, description, price,
+        return new Course(id, instructorId, categoryId, title, description, price,
                 difficulty, thumbnail, totalDuration, CourseStatus.REJECTED, reason,
                 ratingAvg, reviewCount, studentCount, createdAt, LocalDateTime.now(),
                 null, sessions);
@@ -126,7 +124,6 @@ public class Course {
     public Long getId() { return id; }
     public Long getInstructorId() { return instructorId; }
     public Long getCategoryId() { return categoryId; }
-    public Long getNcsInfoId() { return ncsInfoId; }
     public String getTitle() { return title; }
     public String getDescription() { return description; }
     public Long getPrice() { return price; }

--- a/src/main/java/com/sashimi/course/infrastructure/persistence/CategoryPortAdapter.java
+++ b/src/main/java/com/sashimi/course/infrastructure/persistence/CategoryPortAdapter.java
@@ -38,4 +38,11 @@ public class CategoryPortAdapter implements CategoryPort {
                 .orElseThrow(() -> new BusinessException(ErrorCode.CATEGORY_NOT_FOUND))
                 .getSubCategory();
     }
+
+    @Override
+    public Long getNcsInfoIdByCategoryId(Long categoryId) {
+        return categoryRepository.findById(categoryId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.CATEGORY_NOT_FOUND))
+                .getNcsInfoId();
+    }
 }

--- a/src/main/java/com/sashimi/course/infrastructure/persistence/CourseJpaEntity.java
+++ b/src/main/java/com/sashimi/course/infrastructure/persistence/CourseJpaEntity.java
@@ -68,16 +68,13 @@ public class CourseJpaEntity {
     @Column(name = "instructor_id", nullable = false)
     private Long instructorId;
 
-    @Column(name = "ncs_info_id")
-    private Long ncsInfoId;
-
     @OneToMany(mappedBy = "course", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
     @OrderBy("sessionOrder ASC")
     private List<CourseSessionJpaEntity> sessions = new ArrayList<>();
 
     protected CourseJpaEntity() {}
 
-    public CourseJpaEntity(Long instructorId, Long categoryId, Long ncsInfoId,
+    public CourseJpaEntity(Long instructorId, Long categoryId,
                            String title, String description,
                            Long price, CourseDifficulty difficulty, String thumbnail,
                            int totalDuration, CourseStatus status, String rejectReason,
@@ -85,7 +82,6 @@ public class CourseJpaEntity {
                            LocalDateTime createdAt, LocalDateTime updatedAt, LocalDateTime approvedAt) {
         this.instructorId = instructorId;
         this.categoryId = categoryId;
-        this.ncsInfoId = ncsInfoId;
         this.title = title;
         this.description = description;
         this.price = price;
@@ -102,11 +98,10 @@ public class CourseJpaEntity {
         this.approvedAt = approvedAt;
     }
 
-    public void update(Long categoryId, Long ncsInfoId, String title, String description, Long price,
+    public void update(Long categoryId, String title, String description, Long price,
                        CourseDifficulty difficulty, String thumbnail, int totalDuration,
                        CourseStatus status, LocalDateTime updatedAt) {
         this.categoryId = categoryId;
-        this.ncsInfoId = ncsInfoId;
         this.title = title;
         this.description = description;
         this.price = price;
@@ -143,7 +138,6 @@ public class CourseJpaEntity {
     public Long getId() { return id; }
     public Long getInstructorId() { return instructorId; }
     public Long getCategoryId() { return categoryId; }
-    public Long getNcsInfoId() { return ncsInfoId; }
     public String getTitle() { return title; }
     public String getDescription() { return description; }
     public Long getPrice() { return price; }

--- a/src/main/java/com/sashimi/course/infrastructure/persistence/CourseRepositoryAdapter.java
+++ b/src/main/java/com/sashimi/course/infrastructure/persistence/CourseRepositoryAdapter.java
@@ -28,7 +28,8 @@ public class CourseRepositoryAdapter implements CourseRepository {
 
     private Course saveNew(Course course) {
         CourseJpaEntity entity = new CourseJpaEntity(
-                course.getInstructorId(), course.getCategoryId(), course.getNcsInfoId(), course.getTitle(),                course.getDescription(), course.getPrice(), course.getDifficulty(),
+                course.getInstructorId(), course.getCategoryId(),course.getTitle(),
+                course.getDescription(), course.getPrice(), course.getDifficulty(),
                 course.getThumbnail(), course.getTotalDuration(), course.getStatus(),
                 course.getRejectReason(), course.getRatingAvg(), course.getReviewCount(),
                 course.getStudentCount(), course.getCreatedAt(), course.getUpdatedAt(),
@@ -44,7 +45,7 @@ public class CourseRepositoryAdapter implements CourseRepository {
         CourseJpaEntity entity = springDataCourseRepository.findById(course.getId())
                 .orElseThrow(() -> new IllegalStateException("Course not found: " + course.getId()));
 
-        entity.update(course.getCategoryId(), course.getNcsInfoId(), course.getTitle(), course.getDescription(),
+        entity.update(course.getCategoryId(), course.getTitle(), course.getDescription(),
                 course.getPrice(), course.getDifficulty(), course.getThumbnail(),
                 course.getTotalDuration(), course.getStatus(), course.getUpdatedAt());
 
@@ -110,7 +111,7 @@ public class CourseRepositoryAdapter implements CourseRepository {
                         s.getAttachmentType(), s.getAttachmentSize(), s.getCreatedAt(), s.getUpdatedAt()))
                 .toList();
 
-        return Course.restore(entity.getId(), entity.getInstructorId(), entity.getCategoryId(), entity.getNcsInfoId(),
+        return Course.restore(entity.getId(), entity.getInstructorId(), entity.getCategoryId(),
                 entity.getTitle(), entity.getDescription(), entity.getPrice(), entity.getDifficulty(),
                 entity.getThumbnail(), entity.getTotalDuration(), entity.getStatus(),
                 entity.getRejectReason(), entity.getRatingAvg(), entity.getReviewCount(),

--- a/src/main/java/com/sashimi/course/infrastructure/persistence/NcsInfoQueryPortAdapter.java
+++ b/src/main/java/com/sashimi/course/infrastructure/persistence/NcsInfoQueryPortAdapter.java
@@ -1,0 +1,58 @@
+package com.sashimi.course.infrastructure.persistence;
+
+import com.sashimi.course.application.port.NcsInfoQueryPort;
+import com.sashimi.course.application.port.NcsInfoView;
+import com.sashimi.ncs.infrastructure.persistence.NcsInfoJpaEntity;
+import com.sashimi.ncs.infrastructure.persistence.SpringDataNcsInfoRepository;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.Optional;
+
+@Component
+public class NcsInfoQueryPortAdapter implements NcsInfoQueryPort {
+
+    private static final int DISPLAY_ABILITY_UNIT_LIMIT = 3;
+
+    private final SpringDataNcsInfoRepository springDataNcsInfoRepository;
+
+    public NcsInfoQueryPortAdapter(SpringDataNcsInfoRepository springDataNcsInfoRepository) {
+        this.springDataNcsInfoRepository = springDataNcsInfoRepository;
+    }
+
+    @Override
+    public Optional<NcsInfoView> findViewByRepresentativeId(Long ncsInfoId) {
+        return springDataNcsInfoRepository.findById(ncsInfoId)
+                .map(this::toView);
+    }
+
+    private NcsInfoView toView(NcsInfoJpaEntity representative) {
+        List<String> allAbilityUnitNames = springDataNcsInfoRepository
+                .findByJobNameOrderByAbilityUnitCodeAsc(representative.getJobName())
+                .stream()
+                .map(NcsInfoJpaEntity::getAbilityUnitName)
+                .map(this::cleanAbilityUnitName)
+                .filter(name -> name != null && !name.isBlank())
+                .distinct()
+                .toList();
+
+        List<String> displayAbilityUnitNames = allAbilityUnitNames.stream()
+                .limit(DISPLAY_ABILITY_UNIT_LIMIT)
+                .toList();
+
+        return new NcsInfoView(
+                representative.getCategoryPath(),
+                representative.getJobDescription(),
+                displayAbilityUnitNames,
+                allAbilityUnitNames.size()
+        );
+    }
+
+    private String cleanAbilityUnitName(String abilityUnitName) {
+        if (abilityUnitName == null) {
+            return null;
+        }
+
+        return abilityUnitName.replaceFirst("^\\d+\\.", "");
+    }
+}

--- a/src/main/java/com/sashimi/course/presentation/api/InstructorCourseController.java
+++ b/src/main/java/com/sashimi/course/presentation/api/InstructorCourseController.java
@@ -62,7 +62,7 @@ public class InstructorCourseController {
         Long courseId = courseCommandUseCase.createCourse(new CreateCourseCommand(
                 instructorId, request.subCategoryName(), request.title(), request.description(),
                 request.price(), request.difficulty(), request.thumbnail(),
-                request.ncsInfoId(), request.initialStatus(), sessionCommands));
+                request.initialStatus(), sessionCommands));
 
         return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.of("성공했습니다."));
     }
@@ -79,7 +79,7 @@ public class InstructorCourseController {
         courseCommandUseCase.updateCourse(new UpdateCourseCommand(
                 courseId, instructorId, request.categoryId(), request.title(), request.description(),
                 request.price(), request.difficulty(), request.thumbnail(),
-                request.ncsInfoId(), request.targetStatus(), sessionCommands));
+                request.targetStatus(), sessionCommands));
 
         return ResponseEntity.noContent().build();
     }

--- a/src/main/java/com/sashimi/course/presentation/api/request/CreateCourseRequest.java
+++ b/src/main/java/com/sashimi/course/presentation/api/request/CreateCourseRequest.java
@@ -12,7 +12,6 @@ public record CreateCourseRequest(
         Long price,
         CourseDifficulty difficulty,
         String thumbnail,
-        Long ncsInfoId,
         CourseStatus initialStatus,
         List<CreateSessionRequest> sessions
 ) {}

--- a/src/main/java/com/sashimi/course/presentation/api/request/UpdateCourseRequest.java
+++ b/src/main/java/com/sashimi/course/presentation/api/request/UpdateCourseRequest.java
@@ -12,7 +12,6 @@ public record UpdateCourseRequest(
         Long price,
         CourseDifficulty difficulty,
         String thumbnail,
-        Long ncsInfoId,
         CourseStatus targetStatus,
         List<CreateSessionRequest> sessions
 ) {}

--- a/src/main/java/com/sashimi/course/presentation/api/response/PublicCourseDetailResponse.java
+++ b/src/main/java/com/sashimi/course/presentation/api/response/PublicCourseDetailResponse.java
@@ -19,6 +19,7 @@ public record PublicCourseDetailResponse(
         int studentCount,
         String instructorName,
         String categoryName,
+        NcsInfoResponse ncs,
         List<SessionResponse> sessions
 ) {
     public record SessionResponse(
@@ -30,18 +31,47 @@ public record PublicCourseDetailResponse(
             boolean preview
     ) {}
 
+    public record NcsInfoResponse(
+            String categoryPath,
+            String jobDescription,
+            List<String> abilityUnitNames,
+            int totalAbilityUnitCount
+    ) {}
+
     public static PublicCourseDetailResponse from(PublicCourseDetailView view) {
         List<SessionResponse> sessions = view.sessions().stream()
                 .map(s -> new SessionResponse(
-                        s.sessionId(), s.title(), s.videoUrl(),
-                        s.durationSeconds(), s.sessionOrder(), s.preview()
+                        s.sessionId(),
+                        s.title(),
+                        s.videoUrl(),
+                        s.durationSeconds(),
+                        s.sessionOrder(),
+                        s.preview()
                 ))
                 .toList();
+
+        NcsInfoResponse ncs = view.ncs() == null ? null : new NcsInfoResponse(
+                view.ncs().categoryPath(),
+                view.ncs().jobDescription(),
+                view.ncs().abilityUnitNames(),
+                view.ncs().totalAbilityUnitCount()
+        );
+
         return new PublicCourseDetailResponse(
-                view.courseId(), view.title(), view.description(),
-                view.price(), view.difficulty(), view.thumbnail(),
-                view.totalDuration(), view.ratingAvg(), view.reviewCount(),
-                view.studentCount(), view.instructorName(), view.categoryName(), sessions
+                view.courseId(),
+                view.title(),
+                view.description(),
+                view.price(),
+                view.difficulty(),
+                view.thumbnail(),
+                view.totalDuration(),
+                view.ratingAvg(),
+                view.reviewCount(),
+                view.studentCount(),
+                view.instructorName(),
+                view.categoryName(),
+                ncs,
+                sessions
         );
     }
 }

--- a/src/main/java/com/sashimi/global/exception/ErrorCode.java
+++ b/src/main/java/com/sashimi/global/exception/ErrorCode.java
@@ -46,6 +46,7 @@ public enum ErrorCode {
     COURSE_NOT_PURCHASABLE(400, "COURSE_005", "구매할 수 없는 강의입니다."),
 
     CATEGORY_NOT_FOUND(404, "CATEGORY_404", "카테고리를 찾을 수 없습니다."),
+    NCS_INFO_NOT_FOUND(404, "NCS_404", "NCS 정보를 찾을 수 없습니다."),
 
     CART_ITEM_NOT_FOUND(404, "CART_001", "장바구니 항목을 찾을 수 없습니다."),
     CART_ITEM_ALREADY_EXISTS(409, "CART_002", "이미 장바구니에 담긴 강의입니다."),

--- a/src/main/java/com/sashimi/ncs/application/service/NcsSyncService.java
+++ b/src/main/java/com/sashimi/ncs/application/service/NcsSyncService.java
@@ -1,0 +1,149 @@
+package com.sashimi.ncs.application.service;
+
+import com.sashimi.category.infrastructure.persistence.CategoryJpaEntity;
+import com.sashimi.category.infrastructure.persistence.SpringDataCategoryRepository;
+import com.sashimi.ncs.infrastructure.persistence.NcsInfoJpaEntity;
+import com.sashimi.ncs.infrastructure.persistence.SpringDataNcsInfoRepository;
+import com.sashimi.ncs.infrastructure.publicdata.NcsApiClient;
+import com.sashimi.ncs.infrastructure.publicdata.NcsCompeUnitApiResponse;
+import com.sashimi.ncs.infrastructure.publicdata.NcsDutyApiResponse;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+@Service
+@Transactional
+public class NcsSyncService {
+
+    private static final String SUCCESS_CODE = "000";
+
+    private static final Map<String, String> CATEGORY_MAPPING_KEYWORDS = Map.of(
+            "정보처리기사", "응용SW엔지니어링",
+            "SQLD", "DB엔지니어링",
+            "빅데이터분석기사", "빅데이터",
+            "컴퓨터활용능력", "사무행정"
+    );
+
+    private final NcsApiClient ncsApiClient;
+    private final SpringDataNcsInfoRepository ncsInfoRepository;
+    private final SpringDataCategoryRepository categoryRepository;
+
+    public NcsSyncService(NcsApiClient ncsApiClient,
+                          SpringDataNcsInfoRepository ncsInfoRepository,
+                          SpringDataCategoryRepository categoryRepository) {
+        this.ncsApiClient = ncsApiClient;
+        this.ncsInfoRepository = ncsInfoRepository;
+        this.categoryRepository = categoryRepository;
+    }
+
+    public int syncByDutyCd(String dutyCd) {
+        NcsDutyApiResponse dutyResponse = ncsApiClient.fetchNcsDutyInfoAsDto(dutyCd, 1);
+        NcsDutyApiResponse.NcsDutyItem duty = extractDuty(dutyResponse, dutyCd);
+
+        int savedCount = 0;
+        int pageNo = 1;
+
+        while (true) {
+            NcsCompeUnitApiResponse unitResponse = ncsApiClient.fetchNcsCompeUnitInfoAsDto(dutyCd, pageNo);
+            validateSuccess(unitResponse.dataInfo().code(), unitResponse.dataInfo().message());
+
+            List<NcsCompeUnitApiResponse.NcsCompeUnitItem> units = unitResponse.data();
+            if (units == null || units.isEmpty()) {
+                break;
+            }
+
+            for (NcsCompeUnitApiResponse.NcsCompeUnitItem unit : units) {
+                upsertNcsInfo(duty, unit);
+                savedCount++;
+            }
+
+            if (pageNo >= unitResponse.dataInfo().totalPage()) {
+                break;
+            }
+
+            pageNo++;
+        }
+
+        mapCategoriesToNcsInfo();
+
+        return savedCount;
+    }
+
+    private NcsDutyApiResponse.NcsDutyItem extractDuty(NcsDutyApiResponse response, String dutyCd) {
+        validateSuccess(response.dataInfo().code(), response.dataInfo().message());
+
+        if (response.data() == null || response.data().isEmpty()) {
+            throw new IllegalStateException("NCS duty not found: " + dutyCd);
+        }
+
+        return response.data().get(0);
+    }
+
+    private void upsertNcsInfo(NcsDutyApiResponse.NcsDutyItem duty,
+                               NcsCompeUnitApiResponse.NcsCompeUnitItem unit) {
+        LocalDateTime syncedAt = LocalDateTime.now();
+
+        NcsInfoJpaEntity ncsInfo = ncsInfoRepository.findByNcsCode(unit.ncsClCd())
+                .orElseGet(() -> new NcsInfoJpaEntity(
+                        unit.ncsClCd(),
+                        duty.dutyNm(),
+                        duty.dutyNm(),
+                        duty.dutyDef(),
+                        unit.compUnitCd(),
+                        unit.compUnitName(),
+                        unit.compUnitDef(),
+                        syncedAt
+                ));
+
+        ncsInfo.updateFromSync(
+                duty.dutyNm(),
+                duty.dutyNm(),
+                duty.dutyDef(),
+                unit.compUnitCd(),
+                unit.compUnitName(),
+                unit.compUnitDef(),
+                syncedAt
+        );
+
+        ncsInfoRepository.save(ncsInfo);
+    }
+
+    private void mapCategoriesToNcsInfo() {
+        List<CategoryJpaEntity> categories = categoryRepository.findAllByActiveTrueOrderBySortOrderAsc();
+
+        for (CategoryJpaEntity category : categories) {
+            resolveMappingKeyword(category.getSubCategory())
+                    .flatMap(this::findNcsInfoByKeyword)
+                    .ifPresent(ncsInfo -> category.updateNcsInfoId(ncsInfo.getId()));
+        }
+    }
+
+    private Optional<String> resolveMappingKeyword(String subCategory) {
+        if (subCategory == null || subCategory.isBlank()) {
+            return Optional.empty();
+        }
+
+        return CATEGORY_MAPPING_KEYWORDS.entrySet().stream()
+                .filter(entry -> subCategory.contains(entry.getKey()))
+                .map(Map.Entry::getValue)
+                .findFirst();
+    }
+
+    private Optional<NcsInfoJpaEntity> findNcsInfoByKeyword(String keyword) {
+        return ncsInfoRepository.findFirstByCategoryPathContainingOrJobNameContainingOrAbilityUnitNameContaining(
+                keyword,
+                keyword,
+                keyword
+        );
+    }
+
+    private void validateSuccess(String code, String message) {
+        if (!SUCCESS_CODE.equals(code)) {
+            throw new IllegalStateException("NCS API failed: " + code + " / " + message);
+        }
+    }
+}

--- a/src/main/java/com/sashimi/ncs/domain/model/NcsInfo.java
+++ b/src/main/java/com/sashimi/ncs/domain/model/NcsInfo.java
@@ -1,4 +1,0 @@
-package com.sashimi.ncs.domain.model;
-
-public class NcsInfo {
-}

--- a/src/main/java/com/sashimi/ncs/infrastructure/persistence/SpringDataNcsInfoRepository.java
+++ b/src/main/java/com/sashimi/ncs/infrastructure/persistence/SpringDataNcsInfoRepository.java
@@ -2,8 +2,17 @@ package com.sashimi.ncs.infrastructure.persistence;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface SpringDataNcsInfoRepository extends JpaRepository<NcsInfoJpaEntity, Long> {
     Optional<NcsInfoJpaEntity> findByNcsCode(String ncsCode);
+
+    Optional<NcsInfoJpaEntity> findFirstByCategoryPathContainingOrJobNameContainingOrAbilityUnitNameContaining(
+            String categoryPathKeyword,
+            String jobNameKeyword,
+            String abilityUnitNameKeyword
+    );
+
+    List<NcsInfoJpaEntity> findByJobNameOrderByAbilityUnitCodeAsc(String jobName);
 }

--- a/src/main/java/com/sashimi/ncs/infrastructure/publicdata/NcsApiClient.java
+++ b/src/main/java/com/sashimi/ncs/infrastructure/publicdata/NcsApiClient.java
@@ -1,0 +1,79 @@
+package com.sashimi.ncs.infrastructure.publicdata;
+
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestClient;
+
+@Component
+public class NcsApiClient {
+
+    private final RestClient restClient;
+    private final NcsApiProperties properties;
+
+    public NcsApiClient(NcsApiProperties properties) {
+        this.properties = properties;
+        this.restClient = RestClient.builder()
+                .baseUrl(properties.baseUrl())
+                .build();
+    }
+
+    public String fetchNcsCodeInfo(int pageNo) {
+        return fetchWithoutDutyCd("/ncsCdInfo", pageNo);
+    }
+
+    public String fetchNcsDutyInfo(String dutyCd, int pageNo) {
+        return fetchWithDutyCd("/ncsDutyInfo", dutyCd, pageNo);
+    }
+
+    public String fetchNcsCompeUnitInfo(String dutyCd, int pageNo) {
+        return fetchWithDutyCd("/ncsCompeUnitInfo", dutyCd, pageNo);
+    }
+
+    private String fetchWithoutDutyCd(String path, int pageNo) {
+        return restClient.get()
+                .uri(uriBuilder -> uriBuilder
+                        .path(path)
+                        .queryParam("serviceKey", properties.serviceKey())
+                        .queryParam("pageNo", pageNo)
+                        .queryParam("numOfRows", properties.numOfRows())
+                        .queryParam("returnType", "json")
+                        .build())
+                .retrieve()
+                .body(String.class);
+    }
+
+    private String fetchWithDutyCd(String path, String dutyCd, int pageNo) {
+        return restClient.get()
+                .uri(uriBuilder -> uriBuilder
+                        .path(path)
+                        .queryParam("serviceKey", properties.serviceKey())
+                        .queryParam("pageNo", pageNo)
+                        .queryParam("numOfRows", properties.numOfRows())
+                        .queryParam("returnType", "json")
+                        .queryParam("dutyCd", dutyCd)
+                        .build())
+                .retrieve()
+                .body(String.class);
+    }
+
+    public NcsDutyApiResponse fetchNcsDutyInfoAsDto(String dutyCd, int pageNo) {
+        return fetchWithDutyCdAsDto("/ncsDutyInfo", dutyCd, pageNo, NcsDutyApiResponse.class);
+    }
+
+    public NcsCompeUnitApiResponse fetchNcsCompeUnitInfoAsDto(String dutyCd, int pageNo) {
+        return fetchWithDutyCdAsDto("/ncsCompeUnitInfo", dutyCd, pageNo, NcsCompeUnitApiResponse.class);
+    }
+
+    private <T> T fetchWithDutyCdAsDto(String path, String dutyCd, int pageNo, Class<T> responseType) {
+        return restClient.get()
+                .uri(uriBuilder -> uriBuilder
+                        .path(path)
+                        .queryParam("serviceKey", properties.serviceKey())
+                        .queryParam("pageNo", pageNo)
+                        .queryParam("numOfRows", properties.numOfRows())
+                        .queryParam("returnType", "json")
+                        .queryParam("dutyCd", dutyCd)
+                        .build())
+                .retrieve()
+                .body(responseType);
+    }
+}

--- a/src/main/java/com/sashimi/ncs/infrastructure/publicdata/NcsApiProperties.java
+++ b/src/main/java/com/sashimi/ncs/infrastructure/publicdata/NcsApiProperties.java
@@ -1,0 +1,10 @@
+package com.sashimi.ncs.infrastructure.publicdata;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "external.ncs")
+public record NcsApiProperties(
+        String baseUrl,
+        String serviceKey,
+        int numOfRows
+) {}

--- a/src/main/java/com/sashimi/ncs/infrastructure/publicdata/NcsCompeUnitApiResponse.java
+++ b/src/main/java/com/sashimi/ncs/infrastructure/publicdata/NcsCompeUnitApiResponse.java
@@ -1,0 +1,26 @@
+package com.sashimi.ncs.infrastructure.publicdata;
+
+import java.util.List;
+
+public record NcsCompeUnitApiResponse(
+        List<NcsCompeUnitItem> data,
+        DataInfo dataInfo
+) {
+    public record NcsCompeUnitItem(
+            String dutyCd,
+            String dutySvcNo,
+            String ncsClCd,
+            String compUnitCd,
+            String compUnitName,
+            String compUnitDef,
+            Integer compUnitLevel
+    ) {}
+
+    public record DataInfo(
+            String code,
+            String message,
+            int totalPage,
+            String pageNo,
+            int totCnt
+    ) {}
+}

--- a/src/main/java/com/sashimi/ncs/infrastructure/publicdata/NcsDutyApiResponse.java
+++ b/src/main/java/com/sashimi/ncs/infrastructure/publicdata/NcsDutyApiResponse.java
@@ -1,0 +1,23 @@
+package com.sashimi.ncs.infrastructure.publicdata;
+
+import java.util.List;
+
+public record NcsDutyApiResponse(
+        List<NcsDutyItem> data,
+        DataInfo dataInfo
+) {
+    public record NcsDutyItem(
+            String dutyCd,
+            String dutyNm,
+            String dutySvcNo,
+            String dutyDef
+    ) {}
+
+    public record DataInfo(
+            String code,
+            String message,
+            int totalPage,
+            String pageNo,
+            int totCnt
+    ) {}
+}

--- a/src/main/java/com/sashimi/ncs/presentation/api/AdminNcsController.java
+++ b/src/main/java/com/sashimi/ncs/presentation/api/AdminNcsController.java
@@ -1,0 +1,45 @@
+package com.sashimi.ncs.presentation.api;
+
+import com.sashimi.ncs.application.service.NcsSyncService;
+import com.sashimi.ncs.infrastructure.publicdata.NcsApiClient;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/admin/ncs")
+public class AdminNcsController {
+
+    private final NcsApiClient ncsApiClient;
+    private final NcsSyncService ncsSyncService;
+
+    public AdminNcsController(NcsApiClient ncsApiClient, NcsSyncService ncsSyncService) {
+        this.ncsApiClient = ncsApiClient;
+        this.ncsSyncService = ncsSyncService;
+    }
+
+    @PostMapping("/sync")
+    public ResponseEntity<NcsSyncResponse> sync(@RequestParam String dutyCd) {
+        int syncedCount = ncsSyncService.syncByDutyCd(dutyCd);
+        return ResponseEntity.ok(new NcsSyncResponse(dutyCd, syncedCount));
+    }
+
+    @PostMapping("/sync-test/compe-units")
+    public ResponseEntity<String> syncCompeUnitTest(@RequestParam String dutyCd) {
+        return ResponseEntity.ok(ncsApiClient.fetchNcsCompeUnitInfo(dutyCd, 1));
+    }
+
+    @PostMapping("/sync-test/codes")
+    public ResponseEntity<String> syncCodeTest(@RequestParam(defaultValue = "1") int pageNo) {
+        return ResponseEntity.ok(ncsApiClient.fetchNcsCodeInfo(pageNo));
+    }
+
+    @PostMapping("/sync-test/duties")
+    public ResponseEntity<String> syncDutyTest(@RequestParam String dutyCd) {
+        return ResponseEntity.ok(ncsApiClient.fetchNcsDutyInfo(dutyCd, 1));
+    }
+
+    public record NcsSyncResponse(
+            String dutyCd,
+            int syncedCount
+    ) {}
+}

--- a/src/main/resources/application-local.yaml
+++ b/src/main/resources/application-local.yaml
@@ -51,3 +51,7 @@ file:
 toss:
   payments:
     secret-key: ${TOSS_PAYMENTS_SECRET_KEY:}
+
+external:
+  ncs:
+    service-key: ${NCS_SERVICE_KEY}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -37,3 +37,9 @@ toss:
   payments:
     base-url: https://api.tosspayments.com
     secret-key: ${TOSS_PAYMENTS_SECRET_KEY:}
+
+external:
+  ncs:
+    base-url: https://apis.data.go.kr/B490007/ncsInfo
+    service-key: ${NCS_SERVICE_KEY}
+    num-of-rows: 100

--- a/src/main/resources/db/migration/V2.9__move_ncs_from_course_to_category.sql
+++ b/src/main/resources/db/migration/V2.9__move_ncs_from_course_to_category.sql
@@ -1,0 +1,18 @@
+ALTER TABLE courses
+DROP FOREIGN KEY fk_courses_ncs_info;
+
+DROP INDEX idx_courses_ncs_info_id ON courses;
+
+ALTER TABLE courses
+DROP COLUMN ncs_info_id;
+
+ALTER TABLE categories
+    ADD COLUMN ncs_info_id BIGINT NULL;
+
+CREATE INDEX idx_categories_ncs_info_id ON categories(ncs_info_id);
+
+ALTER TABLE categories
+    ADD CONSTRAINT fk_categories_ncs_info
+        FOREIGN KEY (ncs_info_id) REFERENCES ncs_info(ncs_info_id)
+            ON DELETE SET NULL
+            ON UPDATE CASCADE;


### PR DESCRIPTION
## 📌 PR 요약
- 공공데이터 NCS API 연동을 위한 설정과 Client 추가
- NCS 직무정보/능력단위 API 응답 DTO 추가
- `dutyCd` 기준으로 NCS 정보를 동기화하고 `ncs_info` 테이블에 저장하도록 구현
- 카테고리명 기반 키워드 룰을 통해 `categories.ncs_info_id`를 반자동 매핑하도록 구현
- 강의 상세 조회 응답에 NCS 정보를 포함하도록 개선

---

## 🛠️ 작업 상세 내용 (체크로 선택)
- [X] ✨ FEATURE
- [X] 🔧 UPDATE
- [ ] 🐛 BUGFIX
- [ ] ♻️ REFACTOR
- [ ] 📝 DOCS

---

 ## 세부 내용
- `NcsApiClient`
  - `/ncsCdInfo`, `/ncsDutyInfo`, `/ncsCompeUnitInfo` 호출 기능 추가
  - 테스트용 원문 응답 메서드와 저장용 DTO 응답 메서드 분리

- `NcsSyncService`
  - `dutyCd` 단위 NCS 동기화 구현
  - 직무정보와 능력단위 정보를 조합해 `ncs_info` 저장/갱신
  - 카테고리명 기반 키워드 룰로 NCS 반자동 매핑

- `AdminNcsController`
  - `POST /admin/ncs/sync?dutyCd={dutyCd}` 동기화 API 추가
  - 공공데이터 API 응답 확인용 sync-test API 유지

- `Category`
  - `categories.ncs_info_id`를 통해 카테고리 기준 NCS 연결
  - 강의별 직접 연결 방식 대신 카테고리 기반 연결로 변경

- `Course`
  - 강의 상세 조회 시 `category.ncsInfoId` 기준으로 NCS 정보 조회
  - NCS 정보가 없는 경우에도 강의 상세는 정상 응답하고 `ncs: null`로 처리

- `PublicCourseDetailResponse`
  - `ncs.categoryPath`
  - `ncs.jobDescription`
  - `ncs.abilityUnitNames`
  - `ncs.totalAbilityUnitCount`
  를 응답에 추가

- 능력단위 응답 개선
  - 능력단위명은 대표 3개만 응답
  - 전체 능력단위 개수는 `totalAbilityUnitCount`로 제공
  - 프론트에서 “외 N개” 표시 가능
-------
## 테스트
- Postman으로 공공데이터 API 호출 확인
  - `POST /admin/ncs/sync-test/codes`
  - `POST /admin/ncs/sync-test/duties?dutyCd=01010101`
  - `POST /admin/ncs/sync-test/compe-units?dutyCd=01010101`

- Postman으로 NCS 동기화 확인
  - `POST /admin/ncs/sync?dutyCd=20010202`

- DB 저장 확인
  - `ncs_info` 테이블에 NCS 직무/능력단위 저장 확인
  - `categories.ncs_info_id` 자동 매핑 확인

- 강의 상세 조회 확인
  - `GET /api/courses/{courseId}`
  - NCS 정보가 있는 경우 `ncs` 객체 응답 확인
  - NCS 정보가 없는 경우 `ncs: null` 응답 확인
---

## 🔗 PR 관련 이슈로 닫기
Closes #249

---

## ✅ 체크리스트 (확인 절차)
- [ ] 정상적으로 빌드 및 실행됩니다.
- [ ] 주요 기능이 정상 동작합니다.
- [ ] 불필요한 코드를 제거했습니다.
- [ ] 코드 리뷰 준비가 완료되었습니다.

---

## 💬 리뷰어에게 할 말
- NCS 관련 환경변수 설정 필요합니다.
- MVP에서는 전체 NCS 데이터를 한 번에 동기화하지 않고, 필요한 `dutyCd` 단위로 안전하게 동기화하도록 구현했습니다.
- 관리자 페이지가 없는 현재 상황을 고려해 카테고리명 기반 키워드 룰로 NCS를 반자동 매핑합니다.

---

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 강의 상세 페이지에 NCS(국가직무능력표준) 정보 표시 추가 - 직무 설명 및 능력단위 포함
  * 관리자용 NCS 데이터 동기화 도구 추가

* **Changes**
  * 강의 생성 및 수정 프로세스 간소화
  * NCS 정보 관리 구조 개선

<!-- end of auto-generated comment: release notes by coderabbit.ai -->