### PR TITLE
[FEATURE] #251, 255 이력서 주요이력 OCR(클로바) → Apache POI로 변경, 이력서 파일 형식 검증 추가 (.doxc만 허용)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -60,6 +60,9 @@ dependencies {
     testRuntimeOnly 'com.h2database:h2'
 
     implementation 'org.springframework.boot:spring-boot-starter-mail'
+
+// Apache POI (docx 파싱)
+    implementation 'org.apache.poi:poi-ooxml:5.3.0'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/sashimi/global/exception/ErrorCode.java
+++ b/src/main/java/com/sashimi/global/exception/ErrorCode.java
@@ -91,6 +91,7 @@ public enum ErrorCode {
     CERTIFICATE_OCR_FAILED(400, "MEMBER_005", "자격증 OCR 검증에 실패했습니다."),
     CERTIFICATE_NOT_FOUND(404, "MEMBER_006", "자격증을 찾을 수 없습니다."),
     RESUME_PARSE_FAILED(400, "MEMBER_007", "이력서 파싱 처리에 실패했습니다. 주요 이력 항목을 확인해주세요."),
+    RESUME_INVALID_FORMAT(400, "MEMBER_008", "이력서 파일은 .docx 형식만 업로드 가능합니다."),
 
     AI_API_KEY_MISSING(500, "AI_001", "AI API Key가 설정되지 않았습니다."),
     AI_API_KEY_NOT_RESOLVED(500, "AI_002", "AI API Key 환경변수가 정상적으로 치환되지 않았습니다."),

--- a/src/main/java/com/sashimi/global/exception/ErrorCode.java
+++ b/src/main/java/com/sashimi/global/exception/ErrorCode.java
@@ -90,7 +90,7 @@ public enum ErrorCode {
     INVALID_APPLICATION_STATUS(400, "MEMBER_004", "처리할 수 없는 신청 상태입니다."),
     CERTIFICATE_OCR_FAILED(400, "MEMBER_005", "자격증 OCR 검증에 실패했습니다."),
     CERTIFICATE_NOT_FOUND(404, "MEMBER_006", "자격증을 찾을 수 없습니다."),
-    RESUME_OCR_FAILED(400, "MEMBER_007", "이력서 OCR 처리에 실패했습니다. 주요 이력 항목을 확인해주세요."),
+    RESUME_PARSE_FAILED(400, "MEMBER_007", "이력서 파싱 처리에 실패했습니다. 주요 이력 항목을 확인해주세요."),
 
     AI_API_KEY_MISSING(500, "AI_001", "AI API Key가 설정되지 않았습니다."),
     AI_API_KEY_NOT_RESOLVED(500, "AI_002", "AI API Key 환경변수가 정상적으로 치환되지 않았습니다."),

--- a/src/main/java/com/sashimi/member/application/port/DocxPort.java
+++ b/src/main/java/com/sashimi/member/application/port/DocxPort.java
@@ -1,0 +1,8 @@
+package com.sashimi.member.application.port;
+
+import java.util.List;
+
+public interface DocxPort {
+
+    List<String> extractMainCareers(byte[] fileBytes);
+}

--- a/src/main/java/com/sashimi/member/application/port/OcrPort.java
+++ b/src/main/java/com/sashimi/member/application/port/OcrPort.java
@@ -1,13 +1,10 @@
 package com.sashimi.member.application.port;
 
 import java.time.LocalDate;
-import java.util.List;
 
 public interface OcrPort {
 
     OcrResult extractCertificateInfo(byte[] fileBytes, String fileName);
-
-    List<String> extractMainCareers(byte[] fileBytes, String fileName);
 
     record OcrResult(
             String certificationName,

--- a/src/main/java/com/sashimi/member/application/service/MemberCommandService.java
+++ b/src/main/java/com/sashimi/member/application/service/MemberCommandService.java
@@ -61,6 +61,12 @@ public class MemberCommandService implements MemberCommandUseCase {
             throw new BusinessException(ErrorCode.CERTIFICATE_OCR_FAILED);
         }
 
+        // 이력서 파일 형식 검증
+        String resumeFileName = command.resumeFile().fileName();
+        if (resumeFileName == null || !resumeFileName.toLowerCase().endsWith(".docx")) {
+            throw new BusinessException(ErrorCode.RESUME_INVALID_FORMAT);
+        }
+
         // 이력서 docx - 주요 이력 추출
         List<String> mainCareers = docxPort.extractMainCareers(
                 command.resumeFile().fileBytes());

--- a/src/main/java/com/sashimi/member/application/service/MemberCommandService.java
+++ b/src/main/java/com/sashimi/member/application/service/MemberCommandService.java
@@ -4,6 +4,7 @@ import com.sashimi.category.domain.repository.CategoryRepository;
 import com.sashimi.global.exception.BusinessException;
 import com.sashimi.global.exception.ErrorCode;
 import com.sashimi.member.application.command.ApplyInstructorCommand;
+import com.sashimi.member.application.port.DocxPort;
 import com.sashimi.member.application.port.FileStoragePort;
 import com.sashimi.member.application.port.OcrPort;
 import com.sashimi.member.application.usecase.MemberCommandUseCase;
@@ -29,6 +30,7 @@ public class MemberCommandService implements MemberCommandUseCase {
     private final InstructorApplicationRepository instructorApplicationRepository;
     private final UserRepository userRepository;
     private final OcrPort ocrPort;
+    private final DocxPort docxPort;
     private final FileStoragePort fileStoragePort;
     private final CategoryRepository categoryRepository;
 
@@ -59,11 +61,11 @@ public class MemberCommandService implements MemberCommandUseCase {
             throw new BusinessException(ErrorCode.CERTIFICATE_OCR_FAILED);
         }
 
-        // 이력서 OCR - 주요 이력 추출
-        List<String> mainCareers = ocrPort.extractMainCareers(
-                command.resumeFile().fileBytes(), command.resumeFile().fileName());
+        // 이력서 docx - 주요 이력 추출
+        List<String> mainCareers = docxPort.extractMainCareers(
+                command.resumeFile().fileBytes());
         if (mainCareers.isEmpty()) {
-            throw new BusinessException(ErrorCode.RESUME_OCR_FAILED);
+            throw new BusinessException(ErrorCode.RESUME_PARSE_FAILED);
         }
 
         // 중복 신청 방지

--- a/src/main/java/com/sashimi/member/infrastructure/DocxAdapter.java
+++ b/src/main/java/com/sashimi/member/infrastructure/DocxAdapter.java
@@ -1,0 +1,56 @@
+package com.sashimi.member.infrastructure;
+
+import com.sashimi.member.application.port.DocxPort;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.poi.xwpf.usermodel.XWPFDocument;
+import org.apache.poi.xwpf.usermodel.XWPFParagraph;
+import org.springframework.stereotype.Component;
+
+import java.io.ByteArrayInputStream;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+@Slf4j
+@Component
+public class DocxAdapter implements DocxPort {
+
+    @Override
+    public List<String> extractMainCareers(byte[] fileBytes) {
+        try (XWPFDocument doc = new XWPFDocument(new ByteArrayInputStream(fileBytes))) {
+            StringBuilder sb = new StringBuilder();
+            for (XWPFParagraph para : doc.getParagraphs()) {
+                sb.append(para.getText()).append(" ");
+            }
+
+            String text = sb.toString();
+            log.info("이력서 docx 추출 텍스트: {}", text);
+
+            int sectionStart = text.indexOf("주요 이력");
+            if (sectionStart == -1) {
+                sectionStart = text.indexOf("주요이력");
+            }
+            if (sectionStart == -1) {
+                return List.of();
+            }
+            String careerSection = text.substring(sectionStart);
+
+            List<String> careers = new ArrayList<>();
+            Pattern pattern = Pattern.compile("([1-5])\\s+([^1-5위]{5,})");
+            Matcher matcher = pattern.matcher(careerSection);
+            while (matcher.find() && careers.size() < 5) {
+                String content = matcher.group(2).trim();
+                if (!content.contains("자격증, 수상, 주요 경험") && !content.contains("내용")) {
+                    careers.add(content);
+                }
+            }
+
+            return careers;
+
+        } catch (Exception e) {
+            log.error("이력서 docx 파싱 중 예외 발생", e);
+            return List.of();
+        }
+    }
+}

--- a/src/main/java/com/sashimi/member/infrastructure/OcrAdapter.java
+++ b/src/main/java/com/sashimi/member/infrastructure/OcrAdapter.java
@@ -12,9 +12,7 @@ import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.time.LocalDate;
-import java.util.ArrayList;
 import java.util.Base64;
-import java.util.List;
 import java.util.UUID;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -57,71 +55,6 @@ public class OcrAdapter implements OcrPort {
             log.error("Clova OCR 호출 중 예외 발생", e);
             return new OcrResult(null, null, null, false);
         }
-    }
-
-    @Override
-    public List<String> extractMainCareers(byte[] fileBytes, String fileName) {
-        try {
-            String requestBody = buildRequestBody(fileBytes, fileName);
-
-            HttpClient client = HttpClient.newHttpClient();
-            HttpRequest request = HttpRequest.newBuilder()
-                    .uri(URI.create(invokeUrl))
-                    .header("Content-Type", "application/json")
-                    .header("X-OCR-SECRET", secretKey)
-                    .POST(HttpRequest.BodyPublishers.ofString(requestBody))
-                    .build();
-
-            HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString());
-
-            if (response.statusCode() != 200) {
-                log.error("이력서 OCR 호출 실패: status={}", response.statusCode());
-                return List.of();
-            }
-
-            return parseMainCareers(response.body());
-
-        } catch (Exception e) {
-            log.error("이력서 OCR 호출 중 예외 발생", e);
-            return List.of();
-        }
-    }
-
-    private List<String> parseMainCareers(String responseBody) throws Exception {
-        JsonNode root = objectMapper.readTree(responseBody);
-        JsonNode fields = root.path("images").get(0).path("fields");
-
-        StringBuilder fullText = new StringBuilder();
-        for (JsonNode field : fields) {
-            fullText.append(field.path("inferText").asText()).append(" ");
-        }
-
-        String text = fullText.toString();
-        log.info("이력서 OCR 추출 텍스트: {}", text);
-
-        // "주요 이력" 섹션 이후의 텍스트만 대상으로 함
-        int sectionStart = text.indexOf("주요 이력");
-        if (sectionStart == -1) {
-            sectionStart = text.indexOf("주요이력");
-        }
-        if (sectionStart == -1) {
-            return List.of();
-        }
-        String careerSection = text.substring(sectionStart);
-
-        // 1~5번 항목 추출: "1 내용", "2 내용" 패턴
-        List<String> careers = new ArrayList<>();
-        Pattern pattern = Pattern.compile("([1-5])\\s+([^1-5위]{5,})");
-        Matcher matcher = pattern.matcher(careerSection);
-        while (matcher.find() && careers.size() < 5) {
-            String content = matcher.group(2).trim();
-            // 양식 설명 문구 제외
-            if (!content.contains("자격증, 수상, 주요 경험") && !content.contains("내용")) {
-                careers.add(content);
-            }
-        }
-
-        return careers;
     }
 
     private String buildRequestBody(byte[] fileBytes, String fileName) {


### PR DESCRIPTION
## 📌 PR 요약
- 이력서 주요이력을 OCR 대신 Apache POI로 추출하는 걸로 변경

---

## 🛠️ 작업 상세 내용 (체크로 선택)
- [x] ✨ FEATURE
- [x] 🔧 UPDATE
- [ ] 🐛 BUGFIX
- [ ] ♻️ REFACTOR
- [ ] 📝 DOCS

---

## 📋 작업 상세 내용
- 이력서 주요이력 추출 방식을 Clova OCR → Apache POI로 교체
- 이력서 파일 형식이 PDF → DOCX로 변경
-  이력서 파일 업로드 시 .docx 형식 여부 검증 추가
- .docx 외 파일 업로드 시 MEMBER_008 에러 반환
- ("이력서 파일은 .docx 형식만 업로드 가능합

---

## 🔗 PR 관련 이슈로 닫기
Closes #251 , #255 

---

## ✅ 체크리스트 (확인 절차)
- [x] 정상적으로 빌드 및 실행됩니다.
- [x] 주요 기능이 정상 동작합니다.
- [x] 불필요한 코드를 제거했습니다.
- [ ] 코드 리뷰 준비가 완료되었습니다.

---

## 💬 리뷰어에게 할 말
- 사용자 편리성을 위해 이력서 파일 형식을 pdf 에서 docx로 변경했습니다.
- 자격증은 기존과 동일하게 OCR 그대로입니다.

---

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 이력서 DOCX 파일에서 주요 경력 정보를 직접 추출할 수 있도록 개선되었습니다.

* **개선 사항**
  * 이력서 처리 방식이 OCR 기반에서 DOCX 문서 파싱 기반으로 전환되어 정확성이 향상되었습니다.
  * 파일 형식이 올바르지 않으면 형식 오류가 발생하며, 주요 경력 추출 결과가 비어 있을 경우 “파싱 처리 실패(주요 이력 확인)”로 안내됩니다.
  * 관련 오류 메시지가 “OCR 처리 실패”에서 “이력서 파싱 처리 실패/주요 이력 확인”으로 변경되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->