### PR TITLE
[FEATURE] #207 수강평 삭제 기능 구현

### DIFF
--- a/src/main/java/com/sashimi/global/exception/ErrorCode.java
+++ b/src/main/java/com/sashimi/global/exception/ErrorCode.java
@@ -96,6 +96,8 @@ public enum ErrorCode {
     REVIEW_ALREADY_EXISTS(409, "REVIEW_001", "이미 해당 강의에 리뷰를 작성하셨습니다."),
     REVIEW_NOT_ENROLLED(403, "REVIEW_002", "수강 중인 강의에만 리뷰를 작성할 수 있습니다."),
     REVIEW_PROGRESS_REQUIRED(400, "REVIEW_003", "수강 후 리뷰를 작성할 수 있습니다."),
+    REVIEW_NOT_FOUND(404, "REVIEW_404", "수강평을 찾을 수 없습니다."),
+    REVIEW_FORBIDDEN(403, "REVIEW_004", "본인이 작성한 수강평만 삭제할 수 있습니다."),
 
     AI_API_KEY_MISSING(500, "AI_001", "AI API Key가 설정되지 않았습니다."),
     AI_API_KEY_NOT_RESOLVED(500, "AI_002", "AI API Key 환경변수가 정상적으로 치환되지 않았습니다."),

--- a/src/main/java/com/sashimi/review/application/service/ReviewCommandService.java
+++ b/src/main/java/com/sashimi/review/application/service/ReviewCommandService.java
@@ -25,11 +25,11 @@ public class ReviewCommandService implements ReviewCommandUseCase {
     private final CourseRatingPort courseRatingPort;
 
     @Override
-    public void deleteReview(Long userId, Long reviewId) {
+    public void deleteReview(Long userId, Long reviewId, boolean isAdmin) {
         Review review = reviewRepository.findById(reviewId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.REVIEW_NOT_FOUND));
 
-        if (!review.getUserId().equals(userId)) {
+        if (!review.getUserId().equals(userId) && !isAdmin) {
             throw new BusinessException(ErrorCode.REVIEW_FORBIDDEN);
         }
 

--- a/src/main/java/com/sashimi/review/application/service/ReviewCommandService.java
+++ b/src/main/java/com/sashimi/review/application/service/ReviewCommandService.java
@@ -25,6 +25,19 @@ public class ReviewCommandService implements ReviewCommandUseCase {
     private final CourseRatingPort courseRatingPort;
 
     @Override
+    public void deleteReview(Long userId, Long reviewId) {
+        Review review = reviewRepository.findById(reviewId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.REVIEW_NOT_FOUND));
+
+        if (!review.getUserId().equals(userId)) {
+            throw new BusinessException(ErrorCode.REVIEW_FORBIDDEN);
+        }
+
+        reviewRepository.save(review.delete());
+        courseRatingPort.updateRating(review.getCourseId());
+    }
+
+    @Override
     public void writeReview(WriteReviewCommand command) {
         EnrollmentSummary enrollment = enrollmentPort
                 .getEnrollmentByCourse(command.userId(), command.courseId())

--- a/src/main/java/com/sashimi/review/application/usecase/ReviewCommandUseCase.java
+++ b/src/main/java/com/sashimi/review/application/usecase/ReviewCommandUseCase.java
@@ -5,4 +5,6 @@ import com.sashimi.review.application.command.WriteReviewCommand;
 public interface ReviewCommandUseCase {
 
     void writeReview(WriteReviewCommand command);
+
+    void deleteReview(Long userId, Long reviewId);
 }

--- a/src/main/java/com/sashimi/review/application/usecase/ReviewCommandUseCase.java
+++ b/src/main/java/com/sashimi/review/application/usecase/ReviewCommandUseCase.java
@@ -6,5 +6,5 @@ public interface ReviewCommandUseCase {
 
     void writeReview(WriteReviewCommand command);
 
-    void deleteReview(Long userId, Long reviewId);
+    void deleteReview(Long userId, Long reviewId, boolean isAdmin);
 }

--- a/src/main/java/com/sashimi/review/domain/repository/ReviewRepository.java
+++ b/src/main/java/com/sashimi/review/domain/repository/ReviewRepository.java
@@ -2,9 +2,13 @@ package com.sashimi.review.domain.repository;
 
 import com.sashimi.review.domain.model.Review;
 
+import java.util.Optional;
+
 public interface ReviewRepository {
 
     Review save(Review review);
 
     boolean existsByUserIdAndCourseId(Long userId, Long courseId);
+
+    Optional<Review> findById(Long reviewId);
 }

--- a/src/main/java/com/sashimi/review/infrastructure/persistence/ReviewJpaEntity.java
+++ b/src/main/java/com/sashimi/review/infrastructure/persistence/ReviewJpaEntity.java
@@ -46,13 +46,24 @@ public class ReviewJpaEntity {
         this.createdAt = createdAt;
     }
 
+    public ReviewJpaEntity(Long id, Long userId, Long courseId, int rating, String content,
+                           ReviewStatus status, LocalDateTime createdAt) {
+        this.id = id;
+        this.userId = userId;
+        this.courseId = courseId;
+        this.rating = rating;
+        this.content = content;
+        this.status = status;
+        this.createdAt = createdAt;
+    }
+
     public Review toDomain() {
         return Review.restore(id, userId, courseId, rating, content, status, createdAt);
     }
 
     public static ReviewJpaEntity fromDomain(Review review) {
         return new ReviewJpaEntity(
-                review.getUserId(), review.getCourseId(), review.getRating(),
+                review.getId(), review.getUserId(), review.getCourseId(), review.getRating(),
                 review.getContent(), review.getStatus(), review.getCreatedAt()
         );
     }

--- a/src/main/java/com/sashimi/review/infrastructure/persistence/ReviewRepositoryAdapter.java
+++ b/src/main/java/com/sashimi/review/infrastructure/persistence/ReviewRepositoryAdapter.java
@@ -5,6 +5,8 @@ import com.sashimi.review.domain.repository.ReviewRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
+
 @Repository
 @RequiredArgsConstructor
 public class ReviewRepositoryAdapter implements ReviewRepository {
@@ -20,5 +22,10 @@ public class ReviewRepositoryAdapter implements ReviewRepository {
     @Override
     public boolean existsByUserIdAndCourseId(Long userId, Long courseId) {
         return springDataReviewRepository.existsByUserIdAndCourseId(userId, courseId);
+    }
+
+    @Override
+    public Optional<Review> findById(Long reviewId) {
+        return springDataReviewRepository.findById(reviewId).map(ReviewJpaEntity::toDomain);
     }
 }

--- a/src/main/java/com/sashimi/review/presentation/ReviewController.java
+++ b/src/main/java/com/sashimi/review/presentation/ReviewController.java
@@ -19,6 +19,17 @@ public class ReviewController {
 
     private final ReviewCommandUseCase reviewCommandUseCase;
 
+    @Operation(summary = "수강평 삭제", description = "본인이 작성한 수강평을 삭제합니다.")
+    @DeleteMapping("/{reviewId}")
+    public ResponseEntity<ApiResponse<Void>> deleteReview(
+            @PathVariable Long userId,
+            @PathVariable Long courseId,
+            @PathVariable Long reviewId
+    ) {
+        reviewCommandUseCase.deleteReview(userId, reviewId);
+        return ResponseEntity.ok(ApiResponse.of("수강평이 삭제되었습니다."));
+    }
+
     @Operation(summary = "수강평 작성", description = "수강 중인 강의에 평점과 리뷰를 작성합니다.")
     @PostMapping
     public ResponseEntity<ApiResponse<Void>> writeReview(

--- a/src/main/java/com/sashimi/review/presentation/ReviewController.java
+++ b/src/main/java/com/sashimi/review/presentation/ReviewController.java
@@ -4,11 +4,13 @@ import com.sashimi.member.presentation.api.response.ApiResponse;
 import com.sashimi.review.application.command.WriteReviewCommand;
 import com.sashimi.review.application.usecase.ReviewCommandUseCase;
 import com.sashimi.review.presentation.api.request.WriteReviewRequest;
+import com.sashimi.security.principal.CustomUserPrincipal;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -19,14 +21,17 @@ public class ReviewController {
 
     private final ReviewCommandUseCase reviewCommandUseCase;
 
-    @Operation(summary = "수강평 삭제", description = "본인이 작성한 수강평을 삭제합니다.")
+    @Operation(summary = "수강평 삭제", description = "본인이 작성한 수강평을 삭제합니다. 관리자는 타인의 수강평도 삭제 가능합니다.")
     @DeleteMapping("/{reviewId}")
     public ResponseEntity<ApiResponse<Void>> deleteReview(
             @PathVariable Long userId,
             @PathVariable Long courseId,
-            @PathVariable Long reviewId
+            @PathVariable Long reviewId,
+            @AuthenticationPrincipal CustomUserPrincipal principal
     ) {
-        reviewCommandUseCase.deleteReview(userId, reviewId);
+        boolean isAdmin = principal.getAuthorities().stream()
+                .anyMatch(a -> a.getAuthority().equals("ROLE_ADMIN"));
+        reviewCommandUseCase.deleteReview(userId, reviewId, isAdmin);
         return ResponseEntity.ok(ApiResponse.of("수강평이 삭제되었습니다."));
     }
 


### PR DESCRIPTION
## 📌 PR 요약
- 수강생이 본인이 작성한 수강평을 삭제할 수 있는 기능을 구현했습니다.

---

## 🛠️ 작업 상세 내용 (체크로 선택)
- [x] ✨ FEATURE
- [ ] 🔧 UPDATE
- [ ] 🐛 BUGFIX
- [ ] ♻️ REFACTOR
- [ ] 📝 DOCS

---

## 📋 작업 상세 내용
- DELETE /api/users/{userId}/courses/{courseId}/reviews/{reviewId}
- REVIEW_NOT_FOUND — 수강평을 찾을 수 없습니다.
- REVIEW_FORBIDDEN — 본인이 작성한 수강평만 삭제할 수 있습니다.
- 

---

## 🔗 PR 관련 이슈로 닫기
Closes #207 

---

## ✅ 체크리스트 (확인 절차)
- [ ] 정상적으로 빌드 및 실행됩니다.
- [ ] 주요 기능이 정상 동작합니다.
- [ ] 불필요한 코드를 제거했습니다.
- [ ] 코드 리뷰 준비가 완료되었습니다.

---

## 💬 리뷰어에게 할 말
- 

---

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 수강평 삭제 API가 추가되었습니다. 수강평을 삭제하면 해당 코스의 평점 집계가 자동으로 갱신됩니다.
* **권한/오류 처리**
  * 삭제 시 권한에 따라 적절한 오류 응답이 제공되며, 수강평 미존재 및 권한 없음에 대한 오류 코드가 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->