### PR TITLE
[FEATURE] #202 수강평 신고 기능 구현 및 마이그레이션 수정

### DIFF
--- a/src/main/java/com/sashimi/global/config/FlywayConfig.java
+++ b/src/main/java/com/sashimi/global/config/FlywayConfig.java
@@ -19,7 +19,6 @@ public class FlywayConfig {
                 .locations("classpath:db/migration")
                 .baselineOnMigrate(true)
                 .encoding(StandardCharsets.UTF_8)
-
                 .load();
 
 

--- a/src/main/java/com/sashimi/global/exception/ErrorCode.java
+++ b/src/main/java/com/sashimi/global/exception/ErrorCode.java
@@ -98,6 +98,8 @@ public enum ErrorCode {
     REVIEW_PROGRESS_REQUIRED(400, "REVIEW_003", "수강 후 리뷰를 작성할 수 있습니다."),
     REVIEW_NOT_FOUND(404, "REVIEW_404", "수강평을 찾을 수 없습니다."),
     REVIEW_FORBIDDEN(403, "REVIEW_004", "본인이 작성한 수강평만 삭제할 수 있습니다."),
+    REVIEW_ALREADY_REPORTED(409, "REVIEW_005", "이미 신고한 리뷰입니다."),
+    REVIEW_SELF_REPORT_FORBIDDEN(403, "REVIEW_006", "본인이 작성한 수강평은 신고할 수 없습니다."),
 
     AI_API_KEY_MISSING(500, "AI_001", "AI API Key가 설정되지 않았습니다."),
     AI_API_KEY_NOT_RESOLVED(500, "AI_002", "AI API Key 환경변수가 정상적으로 치환되지 않았습니다."),

--- a/src/main/java/com/sashimi/member/application/service/MemberCommandService.java
+++ b/src/main/java/com/sashimi/member/application/service/MemberCommandService.java
@@ -6,7 +6,6 @@ import com.sashimi.global.exception.ErrorCode;
 import com.sashimi.global.storage.FileStoragePort;
 import com.sashimi.member.application.command.ApplyInstructorCommand;
 import com.sashimi.member.application.port.DocxPort;
-import com.sashimi.member.application.port.FileStoragePort;
 import com.sashimi.member.application.port.OcrPort;
 import com.sashimi.member.application.usecase.MemberCommandUseCase;
 import com.sashimi.member.domain.model.ApprovalStatus;

--- a/src/main/java/com/sashimi/review/application/command/ReportReviewCommand.java
+++ b/src/main/java/com/sashimi/review/application/command/ReportReviewCommand.java
@@ -1,0 +1,10 @@
+package com.sashimi.review.application.command;
+
+import com.sashimi.review.domain.model.ReviewReportCategory;
+
+public record ReportReviewCommand(
+        Long userId,
+        Long reviewId,
+        ReviewReportCategory category,
+        String reason
+) {}

--- a/src/main/java/com/sashimi/review/application/service/ReviewReportCommandService.java
+++ b/src/main/java/com/sashimi/review/application/service/ReviewReportCommandService.java
@@ -1,0 +1,40 @@
+package com.sashimi.review.application.service;
+
+import com.sashimi.global.exception.BusinessException;
+import com.sashimi.global.exception.ErrorCode;
+import com.sashimi.review.application.command.ReportReviewCommand;
+import com.sashimi.review.application.usecase.ReviewReportCommandUseCase;
+import com.sashimi.review.domain.model.Review;
+import com.sashimi.review.domain.model.ReviewReport;
+import com.sashimi.review.domain.repository.ReviewReportRepository;
+import com.sashimi.review.domain.repository.ReviewRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class ReviewReportCommandService implements ReviewReportCommandUseCase {
+
+    private final ReviewRepository reviewRepository;
+    private final ReviewReportRepository reviewReportRepository;
+
+    @Override
+    public void reportReview(ReportReviewCommand command) {
+        Review review = reviewRepository.findById(command.reviewId())
+                .orElseThrow(() -> new BusinessException(ErrorCode.REVIEW_NOT_FOUND));
+
+        if (review.getUserId().equals(command.userId())) {
+            throw new BusinessException(ErrorCode.REVIEW_SELF_REPORT_FORBIDDEN);
+        }
+
+        if (reviewReportRepository.existsByReviewIdAndReporterId(command.reviewId(), command.userId())) {
+            throw new BusinessException(ErrorCode.REVIEW_ALREADY_REPORTED);
+        }
+
+        reviewReportRepository.save(
+                ReviewReport.create(command.reviewId(), command.userId(), command.category(), command.reason())
+        );
+    }
+}

--- a/src/main/java/com/sashimi/review/application/usecase/ReviewReportCommandUseCase.java
+++ b/src/main/java/com/sashimi/review/application/usecase/ReviewReportCommandUseCase.java
@@ -1,0 +1,8 @@
+package com.sashimi.review.application.usecase;
+
+import com.sashimi.review.application.command.ReportReviewCommand;
+
+public interface ReviewReportCommandUseCase {
+
+    void reportReview(ReportReviewCommand command);
+}

--- a/src/main/java/com/sashimi/review/domain/model/ReviewReport.java
+++ b/src/main/java/com/sashimi/review/domain/model/ReviewReport.java
@@ -1,0 +1,46 @@
+package com.sashimi.review.domain.model;
+
+import java.time.LocalDateTime;
+
+public class ReviewReport {
+
+    private final Long id;
+    private final Long reviewId;
+    private final Long reporterId;
+    private final ReviewReportCategory category;
+    private final String reason;
+    private final ReviewReportStatus status;
+    private final LocalDateTime createdAt;
+
+    private ReviewReport(Long id, Long reviewId, Long reporterId,
+                         ReviewReportCategory category, String reason,
+                         ReviewReportStatus status, LocalDateTime createdAt) {
+        this.id = id;
+        this.reviewId = reviewId;
+        this.reporterId = reporterId;
+        this.category = category;
+        this.reason = reason;
+        this.status = status;
+        this.createdAt = createdAt;
+    }
+
+    public static ReviewReport create(Long reviewId, Long reporterId,
+                                      ReviewReportCategory category, String reason) {
+        return new ReviewReport(null, reviewId, reporterId, category, reason,
+                ReviewReportStatus.PENDING, LocalDateTime.now());
+    }
+
+    public static ReviewReport restore(Long id, Long reviewId, Long reporterId,
+                                       ReviewReportCategory category, String reason,
+                                       ReviewReportStatus status, LocalDateTime createdAt) {
+        return new ReviewReport(id, reviewId, reporterId, category, reason, status, createdAt);
+    }
+
+    public Long getId() { return id; }
+    public Long getReviewId() { return reviewId; }
+    public Long getReporterId() { return reporterId; }
+    public ReviewReportCategory getCategory() { return category; }
+    public String getReason() { return reason; }
+    public ReviewReportStatus getStatus() { return status; }
+    public LocalDateTime getCreatedAt() { return createdAt; }
+}

--- a/src/main/java/com/sashimi/review/domain/model/ReviewReportCategory.java
+++ b/src/main/java/com/sashimi/review/domain/model/ReviewReportCategory.java
@@ -1,0 +1,8 @@
+package com.sashimi.review.domain.model;
+
+public enum ReviewReportCategory {
+    ABUSE,
+    SPAM,
+    FALSE_INFO,
+    OTHER
+}

--- a/src/main/java/com/sashimi/review/domain/model/ReviewReportStatus.java
+++ b/src/main/java/com/sashimi/review/domain/model/ReviewReportStatus.java
@@ -1,0 +1,6 @@
+package com.sashimi.review.domain.model;
+
+public enum ReviewReportStatus {
+    PENDING,
+    PROCESSED
+}

--- a/src/main/java/com/sashimi/review/domain/repository/ReviewReportRepository.java
+++ b/src/main/java/com/sashimi/review/domain/repository/ReviewReportRepository.java
@@ -1,0 +1,10 @@
+package com.sashimi.review.domain.repository;
+
+import com.sashimi.review.domain.model.ReviewReport;
+
+public interface ReviewReportRepository {
+
+    ReviewReport save(ReviewReport reviewReport);
+
+    boolean existsByReviewIdAndReporterId(Long reviewId, Long reporterId);
+}

--- a/src/main/java/com/sashimi/review/infrastructure/persistence/ReviewReportJpaEntity.java
+++ b/src/main/java/com/sashimi/review/infrastructure/persistence/ReviewReportJpaEntity.java
@@ -1,0 +1,61 @@
+package com.sashimi.review.infrastructure.persistence;
+
+import com.sashimi.review.domain.model.ReviewReport;
+import com.sashimi.review.domain.model.ReviewReportCategory;
+import com.sashimi.review.domain.model.ReviewReportStatus;
+import jakarta.persistence.*;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "review_reports")
+public class ReviewReportJpaEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "report_id")
+    private Long id;
+
+    @Column(name = "review_id", nullable = false)
+    private Long reviewId;
+
+    @Column(name = "reporter_id", nullable = false)
+    private Long reporterId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "category", nullable = false)
+    private ReviewReportCategory category;
+
+    @Column(name = "reason", length = 200)
+    private String reason;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", nullable = false)
+    private ReviewReportStatus status;
+
+    @Column(name = "created_at", nullable = false)
+    private LocalDateTime createdAt;
+
+    protected ReviewReportJpaEntity() {}
+
+    public ReviewReportJpaEntity(Long reviewId, Long reporterId, ReviewReportCategory category,
+                                  String reason, ReviewReportStatus status, LocalDateTime createdAt) {
+        this.reviewId = reviewId;
+        this.reporterId = reporterId;
+        this.category = category;
+        this.reason = reason;
+        this.status = status;
+        this.createdAt = createdAt;
+    }
+
+    public ReviewReport toDomain() {
+        return ReviewReport.restore(id, reviewId, reporterId, category, reason, status, createdAt);
+    }
+
+    public static ReviewReportJpaEntity fromDomain(ReviewReport report) {
+        return new ReviewReportJpaEntity(
+                report.getReviewId(), report.getReporterId(), report.getCategory(),
+                report.getReason(), report.getStatus(), report.getCreatedAt()
+        );
+    }
+}

--- a/src/main/java/com/sashimi/review/infrastructure/persistence/ReviewReportRepositoryAdapter.java
+++ b/src/main/java/com/sashimi/review/infrastructure/persistence/ReviewReportRepositoryAdapter.java
@@ -1,0 +1,23 @@
+package com.sashimi.review.infrastructure.persistence;
+
+import com.sashimi.review.domain.model.ReviewReport;
+import com.sashimi.review.domain.repository.ReviewReportRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class ReviewReportRepositoryAdapter implements ReviewReportRepository {
+
+    private final SpringDataReviewReportRepository springDataReviewReportRepository;
+
+    @Override
+    public ReviewReport save(ReviewReport reviewReport) {
+        return springDataReviewReportRepository.save(ReviewReportJpaEntity.fromDomain(reviewReport)).toDomain();
+    }
+
+    @Override
+    public boolean existsByReviewIdAndReporterId(Long reviewId, Long reporterId) {
+        return springDataReviewReportRepository.existsByReviewIdAndReporterId(reviewId, reporterId);
+    }
+}

--- a/src/main/java/com/sashimi/review/infrastructure/persistence/SpringDataReviewReportRepository.java
+++ b/src/main/java/com/sashimi/review/infrastructure/persistence/SpringDataReviewReportRepository.java
@@ -1,0 +1,8 @@
+package com.sashimi.review.infrastructure.persistence;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface SpringDataReviewReportRepository extends JpaRepository<ReviewReportJpaEntity, Long> {
+
+    boolean existsByReviewIdAndReporterId(Long reviewId, Long reporterId);
+}

--- a/src/main/java/com/sashimi/review/presentation/ReviewReportController.java
+++ b/src/main/java/com/sashimi/review/presentation/ReviewReportController.java
@@ -1,0 +1,36 @@
+package com.sashimi.review.presentation;
+
+import com.sashimi.member.presentation.api.response.ApiResponse;
+import com.sashimi.review.application.command.ReportReviewCommand;
+import com.sashimi.review.application.usecase.ReviewReportCommandUseCase;
+import com.sashimi.review.presentation.api.request.ReportReviewRequest;
+import com.sashimi.security.principal.CustomUserPrincipal;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/reviews")
+@RequiredArgsConstructor
+@Tag(name = "수강평 신고 API", description = "수강평 신고 API")
+public class ReviewReportController {
+
+    private final ReviewReportCommandUseCase reviewReportCommandUseCase;
+
+    @Operation(summary = "수강평 신고", description = "부적절한 수강평을 신고합니다.")
+    @PostMapping("/{reviewId}/reports")
+    public ResponseEntity<ApiResponse<Void>> reportReview(
+            @PathVariable Long reviewId,
+            @AuthenticationPrincipal CustomUserPrincipal principal,
+            @Valid @RequestBody ReportReviewRequest request
+    ) {
+        reviewReportCommandUseCase.reportReview(
+                new ReportReviewCommand(principal.getId(), reviewId, request.category(), request.reason())
+        );
+        return ResponseEntity.ok(ApiResponse.of("신고가 접수되었습니다."));
+    }
+}

--- a/src/main/java/com/sashimi/review/presentation/api/request/ReportReviewRequest.java
+++ b/src/main/java/com/sashimi/review/presentation/api/request/ReportReviewRequest.java
@@ -1,0 +1,13 @@
+package com.sashimi.review.presentation.api.request;
+
+import com.sashimi.review.domain.model.ReviewReportCategory;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+public record ReportReviewRequest(
+        @NotNull(message = "신고 카테고리를 선택해주세요.")
+        ReviewReportCategory category,
+
+        @Size(max = 200, message = "신고 사유는 200자 이내로 입력해주세요.")
+        String reason
+) {}

--- a/src/main/java/com/sashimi/security/config/SecurityConfig.java
+++ b/src/main/java/com/sashimi/security/config/SecurityConfig.java
@@ -71,7 +71,7 @@ public class SecurityConfig {
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers(HttpMethod.OPTIONS, "/**").permitAll()
                         .requestMatchers("/auth/**", "/verifications/email/**", "/error").permitAll()
-                        .requestMatchers("/swagger-ui/**", "/v3/api-docs/**").permitAll()
+                        .requestMatchers("/swagger-ui/**", "/swagger-ui.html", "/v3/api-docs/**").permitAll()
                         .requestMatchers(HttpMethod.GET, "/api/courses/**").permitAll()
                         .requestMatchers(HttpMethod.GET, "/api/categories/**").permitAll()
                         .requestMatchers(HttpMethod.GET, "/uploads/**").permitAll()

--- a/src/main/resources/db/migration/V2.11__add_instructor_profile_missing_columns.sql
+++ b/src/main/resources/db/migration/V2.11__add_instructor_profile_missing_columns.sql
@@ -1,8 +1,1 @@
-ALTER TABLE instructor_profiles
-    ADD COLUMN profile_image_path VARCHAR(500) NULL,
-    ADD COLUMN resume_file_path VARCHAR(500) NULL,
-    ADD COLUMN motivation_letter TEXT NULL,
-    ADD COLUMN category_id BIGINT NULL,
-    ADD COLUMN rejection_category VARCHAR(50) NULL,
-    ADD COLUMN rejection_reason VARCHAR(100) NULL,
-    ADD COLUMN main_careers JSON NULL;
+SELECT 1;

--- a/src/main/resources/db/migration/V2.12__create_review_reports.sql
+++ b/src/main/resources/db/migration/V2.12__create_review_reports.sql
@@ -1,0 +1,11 @@
+CREATE TABLE review_reports (
+    report_id   BIGINT AUTO_INCREMENT PRIMARY KEY,
+    review_id   BIGINT       NOT NULL,
+    reporter_id BIGINT       NOT NULL,
+    category    VARCHAR(20)  NOT NULL,
+    reason      VARCHAR(200),
+    status      VARCHAR(20)  NOT NULL DEFAULT 'PENDING',
+    created_at  DATETIME     NOT NULL,
+    CONSTRAINT uq_review_report UNIQUE (review_id, reporter_id),
+    CONSTRAINT fk_review_report_review FOREIGN KEY (review_id) REFERENCES reviews (review_id)
+);


### PR DESCRIPTION
## 📌 PR 요약
- 수강평을 신고하는 기능 구현, DB 수정

---

## 🛠️ 작업 상세 내용 (체크로 선택)
- [x] ✨ FEATURE
- [x] 🔧 UPDATE
- [ ] 🐛 BUGFIX
- [ ] ♻️ REFACTOR
- [ ] 📝 DOCS

---

## 📋 작업 상세 내용
- 수강평 신고 API (POST /api/reviews/{reviewId}/reports)
- 신고 카테고리 선택 필수: ABUSE(욕설 및 비방), SPAM(스팸 및 광고), FALSE_INFO(허위 정보), OTHER(기타)
- 신고 사유 선택 입력 (200자 제한)
- 본인 리뷰 신고 방지
- 중복 신고 방지 (이미 신고한 리뷰 재신고 불가)

## 수강평 삭제 권한 수정                                                                                                                                            
  - 관리자(ROLE_ADMIN)는 타인의 수강평도 삭제 가능하도록 예외 처리 추가

##DB 마이그레이션
- V2.11: V2.10과 중복된 컬럼 추가 문제 수정 → no-op(SELECT 1)으로 변경
- V2.12: review_reports 테이블 신규 생

---

## 🔗 PR 관련 이슈로 닫기
Closes #202 

---

## ✅ 체크리스트 (확인 절차)
- [ ] 정상적으로 빌드 및 실행됩니다.
- [ ] 주요 기능이 정상 동작합니다.
- [ ] 불필요한 코드를 제거했습니다.
- [ ] 코드 리뷰 준비가 완료되었습니다.

---

## 💬 리뷰어에게 할 말
- V2.11 오류 나는 분은 아래 SQL 한 번만 실행 후 재시작해주세요 !!
- USE sixsashimi_db;
- DELETE FROM flyway_schema_history WHERE version = '2.11' AND success = 0;


---

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 리뷰 신고 기능이 추가되었습니다. 사용자는 부적절한 리뷰를 여러 카테고리(욕설, 스팸, 거짓 정보 등)로 신고할 수 있습니다.
  * 신고 시 최대 200자 이내의 사유를 작성할 수 있습니다.

* **보안**
  * Swagger UI 접근성이 개선되었습니다.

* **데이터베이스**
  * 리뷰 신고를 저장하는 데이터베이스 스키마가 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->