### PR TITLE
[FEATURE] #259 관리자 수강평 신고 관리

### DIFF
--- a/src/main/java/com/sashimi/review/application/port/ReviewCoursePort.java
+++ b/src/main/java/com/sashimi/review/application/port/ReviewCoursePort.java
@@ -1,0 +1,6 @@
+package com.sashimi.review.application.port;
+
+public interface ReviewCoursePort {
+
+    String getCourseName(Long courseId);
+}

--- a/src/main/java/com/sashimi/review/application/port/ReviewUserPort.java
+++ b/src/main/java/com/sashimi/review/application/port/ReviewUserPort.java
@@ -1,0 +1,6 @@
+package com.sashimi.review.application.port;
+
+public interface ReviewUserPort {
+
+    String getUserLoginId(Long userId);
+}

--- a/src/main/java/com/sashimi/review/application/service/AdminReviewReportCommandService.java
+++ b/src/main/java/com/sashimi/review/application/service/AdminReviewReportCommandService.java
@@ -1,0 +1,41 @@
+package com.sashimi.review.application.service;
+
+import com.sashimi.global.exception.BusinessException;
+import com.sashimi.global.exception.ErrorCode;
+import com.sashimi.review.application.usecase.AdminReviewReportCommandUseCase;
+import com.sashimi.review.domain.model.Review;
+import com.sashimi.review.domain.model.ReviewReport;
+import com.sashimi.review.domain.repository.ReviewReportRepository;
+import com.sashimi.review.domain.repository.ReviewRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class AdminReviewReportCommandService implements AdminReviewReportCommandUseCase {
+
+    private final ReviewReportRepository reviewReportRepository;
+    private final ReviewRepository reviewRepository;
+
+    @Override
+    public void deleteReportedReview(Long reportId) {
+        ReviewReport report = reviewReportRepository.findById(reportId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.REVIEW_NOT_FOUND));
+
+        Review review = reviewRepository.findById(report.getReviewId())
+                .orElseThrow(() -> new BusinessException(ErrorCode.REVIEW_NOT_FOUND));
+
+        reviewRepository.save(review.delete());
+        reviewReportRepository.save(report.process());
+    }
+
+    @Override
+    public void rejectReport(Long reportId) {
+        ReviewReport report = reviewReportRepository.findById(reportId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.REVIEW_NOT_FOUND));
+
+        reviewReportRepository.save(report.process());
+    }
+}

--- a/src/main/java/com/sashimi/review/application/service/AdminReviewReportQueryService.java
+++ b/src/main/java/com/sashimi/review/application/service/AdminReviewReportQueryService.java
@@ -1,0 +1,74 @@
+package com.sashimi.review.application.service;
+
+import com.sashimi.global.exception.BusinessException;
+import com.sashimi.global.exception.ErrorCode;
+import com.sashimi.review.application.port.ReviewCoursePort;
+import com.sashimi.review.application.port.ReviewUserPort;
+import com.sashimi.review.application.usecase.AdminReviewReportQueryUseCase;
+import com.sashimi.review.domain.model.Review;
+import com.sashimi.review.domain.model.ReviewReport;
+import com.sashimi.review.domain.model.ReviewReportStatus;
+import com.sashimi.review.domain.repository.ReviewReportRepository;
+import com.sashimi.review.domain.repository.ReviewRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class AdminReviewReportQueryService implements AdminReviewReportQueryUseCase {
+
+    private final ReviewReportRepository reviewReportRepository;
+    private final ReviewRepository reviewRepository;
+    private final ReviewCoursePort reviewCoursePort;
+    private final ReviewUserPort reviewUserPort;
+
+    @Override
+    public List<ReportSummary> getReports(ReviewReportStatus status) {
+        List<ReviewReport> reports = status == null
+                ? reviewReportRepository.findAll()
+                : reviewReportRepository.findAllByStatus(status);
+
+        return reports.stream()
+                .map(report -> {
+                    Review review = reviewRepository.findById(report.getReviewId())
+                            .orElseThrow(() -> new BusinessException(ErrorCode.REVIEW_NOT_FOUND));
+                    String courseName = reviewCoursePort.getCourseName(review.getCourseId());
+                    String writerLoginId = reviewUserPort.getUserLoginId(review.getUserId());
+                    return new ReportSummary(
+                            report.getId(),
+                            review.getContent(),
+                            courseName,
+                            writerLoginId,
+                            report.getCategory(),
+                            report.getCreatedAt(),
+                            report.getStatus()
+                    );
+                })
+                .toList();
+    }
+
+    @Override
+    public ReportDetail getReport(Long reportId) {
+        ReviewReport report = reviewReportRepository.findById(reportId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.REVIEW_NOT_FOUND));
+
+        Review review = reviewRepository.findById(report.getReviewId())
+                .orElseThrow(() -> new BusinessException(ErrorCode.REVIEW_NOT_FOUND));
+
+        String writerLoginId = reviewUserPort.getUserLoginId(review.getUserId());
+        String reporterLoginId = reviewUserPort.getUserLoginId(report.getReporterId());
+
+        return new ReportDetail(
+                review.getContent(),
+                writerLoginId,
+                reporterLoginId,
+                report.getCreatedAt(),
+                report.getCategory(),
+                report.getReason()
+        );
+    }
+}

--- a/src/main/java/com/sashimi/review/application/usecase/AdminReviewReportCommandUseCase.java
+++ b/src/main/java/com/sashimi/review/application/usecase/AdminReviewReportCommandUseCase.java
@@ -1,0 +1,8 @@
+package com.sashimi.review.application.usecase;
+
+public interface AdminReviewReportCommandUseCase {
+
+    void deleteReportedReview(Long reportId);
+
+    void rejectReport(Long reportId);
+}

--- a/src/main/java/com/sashimi/review/application/usecase/AdminReviewReportQueryUseCase.java
+++ b/src/main/java/com/sashimi/review/application/usecase/AdminReviewReportQueryUseCase.java
@@ -1,0 +1,33 @@
+package com.sashimi.review.application.usecase;
+
+import com.sashimi.review.domain.model.ReviewReportCategory;
+import com.sashimi.review.domain.model.ReviewReportStatus;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public interface AdminReviewReportQueryUseCase {
+
+    List<ReportSummary> getReports(ReviewReportStatus status);
+
+    ReportDetail getReport(Long reportId);
+
+    record ReportSummary(
+            Long reportId,
+            String reviewContent,
+            String courseName,
+            String writerLoginId,
+            ReviewReportCategory category,
+            LocalDateTime reportedAt,
+            ReviewReportStatus status
+    ) {}
+
+    record ReportDetail(
+            String reviewContent,
+            String writerLoginId,
+            String reporterLoginId,
+            LocalDateTime reportedAt,
+            ReviewReportCategory category,
+            String reason
+    ) {}
+}

--- a/src/main/java/com/sashimi/review/domain/model/ReviewReport.java
+++ b/src/main/java/com/sashimi/review/domain/model/ReviewReport.java
@@ -36,6 +36,10 @@ public class ReviewReport {
         return new ReviewReport(id, reviewId, reporterId, category, reason, status, createdAt);
     }
 
+    public ReviewReport process() {
+        return new ReviewReport(id, reviewId, reporterId, category, reason, ReviewReportStatus.PROCESSED, createdAt);
+    }
+
     public Long getId() { return id; }
     public Long getReviewId() { return reviewId; }
     public Long getReporterId() { return reporterId; }

--- a/src/main/java/com/sashimi/review/domain/repository/ReviewReportRepository.java
+++ b/src/main/java/com/sashimi/review/domain/repository/ReviewReportRepository.java
@@ -1,10 +1,20 @@
 package com.sashimi.review.domain.repository;
 
 import com.sashimi.review.domain.model.ReviewReport;
+import com.sashimi.review.domain.model.ReviewReportStatus;
+
+import java.util.List;
+import java.util.Optional;
 
 public interface ReviewReportRepository {
 
     ReviewReport save(ReviewReport reviewReport);
 
     boolean existsByReviewIdAndReporterId(Long reviewId, Long reporterId);
+
+    List<ReviewReport> findAll();
+
+    List<ReviewReport> findAllByStatus(ReviewReportStatus status);
+
+    Optional<ReviewReport> findById(Long reportId);
 }

--- a/src/main/java/com/sashimi/review/infrastructure/persistence/ReviewCourseAdapter.java
+++ b/src/main/java/com/sashimi/review/infrastructure/persistence/ReviewCourseAdapter.java
@@ -1,0 +1,22 @@
+package com.sashimi.review.infrastructure.persistence;
+
+import com.sashimi.review.application.port.ReviewCoursePort;
+import lombok.RequiredArgsConstructor;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class ReviewCourseAdapter implements ReviewCoursePort {
+
+    private final JdbcTemplate jdbcTemplate;
+
+    @Override
+    public String getCourseName(Long courseId) {
+        return jdbcTemplate.queryForObject(
+                "SELECT title FROM courses WHERE course_id = ?",
+                String.class,
+                courseId
+        );
+    }
+}

--- a/src/main/java/com/sashimi/review/infrastructure/persistence/ReviewReportRepositoryAdapter.java
+++ b/src/main/java/com/sashimi/review/infrastructure/persistence/ReviewReportRepositoryAdapter.java
@@ -1,9 +1,13 @@
 package com.sashimi.review.infrastructure.persistence;
 
 import com.sashimi.review.domain.model.ReviewReport;
+import com.sashimi.review.domain.model.ReviewReportStatus;
 import com.sashimi.review.domain.repository.ReviewReportRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
 
 @Repository
 @RequiredArgsConstructor
@@ -19,5 +23,25 @@ public class ReviewReportRepositoryAdapter implements ReviewReportRepository {
     @Override
     public boolean existsByReviewIdAndReporterId(Long reviewId, Long reporterId) {
         return springDataReviewReportRepository.existsByReviewIdAndReporterId(reviewId, reporterId);
+    }
+
+    @Override
+    public List<ReviewReport> findAll() {
+        return springDataReviewReportRepository.findAll().stream()
+                .map(ReviewReportJpaEntity::toDomain)
+                .toList();
+    }
+
+    @Override
+    public List<ReviewReport> findAllByStatus(ReviewReportStatus status) {
+        return springDataReviewReportRepository.findAllByStatus(status).stream()
+                .map(ReviewReportJpaEntity::toDomain)
+                .toList();
+    }
+
+    @Override
+    public Optional<ReviewReport> findById(Long reportId) {
+        return springDataReviewReportRepository.findById(reportId)
+                .map(ReviewReportJpaEntity::toDomain);
     }
 }

--- a/src/main/java/com/sashimi/review/infrastructure/persistence/ReviewUserAdapter.java
+++ b/src/main/java/com/sashimi/review/infrastructure/persistence/ReviewUserAdapter.java
@@ -1,0 +1,22 @@
+package com.sashimi.review.infrastructure.persistence;
+
+import com.sashimi.review.application.port.ReviewUserPort;
+import lombok.RequiredArgsConstructor;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class ReviewUserAdapter implements ReviewUserPort {
+
+    private final JdbcTemplate jdbcTemplate;
+
+    @Override
+    public String getUserLoginId(Long userId) {
+        return jdbcTemplate.queryForObject(
+                "SELECT login_id FROM users WHERE user_id = ?",
+                String.class,
+                userId
+        );
+    }
+}

--- a/src/main/java/com/sashimi/review/infrastructure/persistence/SpringDataReviewReportRepository.java
+++ b/src/main/java/com/sashimi/review/infrastructure/persistence/SpringDataReviewReportRepository.java
@@ -1,8 +1,13 @@
 package com.sashimi.review.infrastructure.persistence;
 
+import com.sashimi.review.domain.model.ReviewReportStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
 
 public interface SpringDataReviewReportRepository extends JpaRepository<ReviewReportJpaEntity, Long> {
 
     boolean existsByReviewIdAndReporterId(Long reviewId, Long reporterId);
+
+    List<ReviewReportJpaEntity> findAllByStatus(ReviewReportStatus status);
 }

--- a/src/main/java/com/sashimi/review/presentation/AdminReviewReportController.java
+++ b/src/main/java/com/sashimi/review/presentation/AdminReviewReportController.java
@@ -1,0 +1,58 @@
+package com.sashimi.review.presentation;
+
+import com.sashimi.review.application.usecase.AdminReviewReportCommandUseCase;
+import com.sashimi.review.application.usecase.AdminReviewReportQueryUseCase;
+import com.sashimi.review.domain.model.ReviewReportStatus;
+import com.sashimi.review.presentation.api.response.AdminReviewReportDetailResponse;
+import com.sashimi.review.presentation.api.response.AdminReviewReportListResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/admin/reviews/reports")
+@RequiredArgsConstructor
+@Tag(name = "관리자 수강평 신고 API", description = "관리자 수강평 신고 관리 API")
+public class AdminReviewReportController {
+
+    private final AdminReviewReportQueryUseCase adminReviewReportQueryUseCase;
+    private final AdminReviewReportCommandUseCase adminReviewReportCommandUseCase;
+
+    @Operation(summary = "신고된 수강평 목록 조회", description = "상태별 필터링 가능 (PENDING/PROCESSED). 파라미터 없으면 전체 조회.")
+    @GetMapping
+    public ResponseEntity<List<AdminReviewReportListResponse>> getReports(
+            @RequestParam(required = false) ReviewReportStatus status
+    ) {
+        List<AdminReviewReportListResponse> responses = adminReviewReportQueryUseCase.getReports(status)
+                .stream()
+                .map(AdminReviewReportListResponse::from)
+                .toList();
+        return ResponseEntity.ok(responses);
+    }
+
+    @Operation(summary = "신고 상세 조회", description = "신고 상세 모달에 표시할 데이터를 조회합니다.")
+    @GetMapping("/{reportId}")
+    public ResponseEntity<AdminReviewReportDetailResponse> getReport(@PathVariable Long reportId) {
+        return ResponseEntity.ok(
+                AdminReviewReportDetailResponse.from(adminReviewReportQueryUseCase.getReport(reportId))
+        );
+    }
+
+    @Operation(summary = "신고된 수강평 삭제", description = "수강평을 삭제하고 신고를 처리됨으로 변경합니다.")
+    @PatchMapping("/{reportId}/delete")
+    public ResponseEntity<Void> deleteReportedReview(@PathVariable Long reportId) {
+        adminReviewReportCommandUseCase.deleteReportedReview(reportId);
+        return ResponseEntity.noContent().build();
+    }
+
+    @Operation(summary = "신고 반려", description = "신고를 반려하고 처리됨으로 변경합니다. 수강평은 유지됩니다.")
+    @PatchMapping("/{reportId}/reject")
+    public ResponseEntity<Void> rejectReport(@PathVariable Long reportId) {
+        adminReviewReportCommandUseCase.rejectReport(reportId);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/src/main/java/com/sashimi/review/presentation/api/response/AdminReviewReportDetailResponse.java
+++ b/src/main/java/com/sashimi/review/presentation/api/response/AdminReviewReportDetailResponse.java
@@ -1,0 +1,26 @@
+package com.sashimi.review.presentation.api.response;
+
+import com.sashimi.review.application.usecase.AdminReviewReportQueryUseCase.ReportDetail;
+import com.sashimi.review.domain.model.ReviewReportCategory;
+
+import java.time.LocalDateTime;
+
+public record AdminReviewReportDetailResponse(
+        String reviewContent,
+        String writerLoginId,
+        String reporterLoginId,
+        LocalDateTime reportedAt,
+        ReviewReportCategory category,
+        String reason
+) {
+    public static AdminReviewReportDetailResponse from(ReportDetail detail) {
+        return new AdminReviewReportDetailResponse(
+                detail.reviewContent(),
+                detail.writerLoginId(),
+                detail.reporterLoginId(),
+                detail.reportedAt(),
+                detail.category(),
+                detail.reason()
+        );
+    }
+}

--- a/src/main/java/com/sashimi/review/presentation/api/response/AdminReviewReportListResponse.java
+++ b/src/main/java/com/sashimi/review/presentation/api/response/AdminReviewReportListResponse.java
@@ -1,0 +1,29 @@
+package com.sashimi.review.presentation.api.response;
+
+import com.sashimi.review.application.usecase.AdminReviewReportQueryUseCase.ReportSummary;
+import com.sashimi.review.domain.model.ReviewReportCategory;
+import com.sashimi.review.domain.model.ReviewReportStatus;
+
+import java.time.LocalDateTime;
+
+public record AdminReviewReportListResponse(
+        Long reportId,
+        String reviewContent,
+        String courseName,
+        String writerLoginId,
+        ReviewReportCategory category,
+        LocalDateTime reportedAt,
+        ReviewReportStatus status
+) {
+    public static AdminReviewReportListResponse from(ReportSummary summary) {
+        return new AdminReviewReportListResponse(
+                summary.reportId(),
+                summary.reviewContent(),
+                summary.courseName(),
+                summary.writerLoginId(),
+                summary.category(),
+                summary.reportedAt(),
+                summary.status()
+        );
+    }
+}


### PR DESCRIPTION
## 📌 PR 요약
- 관리자 수강평 신고 목록 조회
---

## 🛠️ 작업 상세 내용 (체크로 선택)
- [x] ✨ FEATURE
- [ ] 🔧 UPDATE
- [ ] 🐛 BUGFIX
- [ ] ♻️ REFACTOR
- [ ] 📝 DOCS

---

## 📋 작업 상세 내용
- 삭제 처리: 수강평 soft delete + 신고 상태 PROCESSED 변경
- 반려 처리: 신고 상태만 PROCESSED 변경 (수강평 유지)
- 목록 응답에 강의명, 작성자 loginId 포함 (Port 패턴으로 조회)
- 상세 응답에 신고된 리뷰 내용, 작성자 ID, 신고자


## api
- GET /admin/reviews/reports - 신고 목록 조회 (status 파라미터로 전체/처리전/처리됨 필터)
- GET /admin/reviews/reports/{reportId} - 신고 상세 조회 (모달용)
- PATCH /admin/reviews/reports/{reportId}/delete - 신고된 수강평 삭제 처리
- PATCH /admin/reviews/reports/{reportId}/reject - 신고 반려 처리
- 

---

## 🔗 PR 관련 이슈로 닫기
Closes #259 

---

## ✅ 체크리스트 (확인 절차)
- [ ] 정상적으로 빌드 및 실행됩니다.
- [ ] 주요 기능이 정상 동작합니다.
- [ ] 불필요한 코드를 제거했습니다.
- [ ] 코드 리뷰 준비가 완료되었습니다.

---

## 💬 리뷰어에게 할 말
- 

---

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 새로운 기능

* **관리자 대시보드에 신고된 수강평 관리 기능 추가**
  * 신고 내역 목록 조회 및 상태별 필터링
  * 신고 상세 정보 확인 (내용, 신고자, 작성자, 신고 이유 등)
  * 신고된 수강평 삭제 및 신고 처리 완료
  * 부적절한 신고 반려 처리

<!-- end of auto-generated comment: release notes by coderabbit.ai -->