### PR TITLE
[FEATURE]  #266 선택 동의 항목 저장 및 강사 지원 자격증 S3 업로드 구현

### DIFF
--- a/src/main/java/com/sashimi/global/storage/LocalFileStorageAdapter.java
+++ b/src/main/java/com/sashimi/global/storage/LocalFileStorageAdapter.java
@@ -3,6 +3,7 @@ package com.sashimi.global.storage;
 import com.sashimi.global.exception.BusinessException;
 import com.sashimi.global.exception.ErrorCode;
 import org.springframework.beans.factory.annotation.Value;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Component;
 import org.springframework.web.multipart.MultipartFile;
@@ -13,6 +14,7 @@ import java.nio.file.Paths;
 import java.util.Set;
 import java.util.UUID;
 
+@Slf4j
 @Profile("local")
 @Component
 public class LocalFileStorageAdapter implements FileStoragePort {
@@ -45,18 +47,30 @@ public class LocalFileStorageAdapter implements FileStoragePort {
 
             return baseUrl + "/uploads/" + fileName;
         } catch (Exception e) {
+            log.error("[Local] 이미지 업로드 실패 - cause: {}", e.getMessage(), e);
             throw new BusinessException(ErrorCode.FILE_UPLOAD_FAILED);
         }
     }
 
     @Override
     public String storePrivate(byte[] bytes, String originalFilename, String folder) {
-        throw new UnsupportedOperationException("로컬 환경에서는 private 파일 저장을 지원하지 않습니다.");
+        try {
+            Path uploadPath = Paths.get(uploadDir, folder).toAbsolutePath().normalize();
+            Files.createDirectories(uploadPath);
+
+            String fileName = UUID.randomUUID() + getExtension(originalFilename);
+            Files.write(uploadPath.resolve(fileName), bytes);
+
+            return folder + "/" + fileName;
+        } catch (Exception e) {
+            log.error("[Local] private 파일 업로드 실패 - folder: {}, file: {}, cause: {}", folder, originalFilename, e.getMessage(), e);
+            throw new BusinessException(ErrorCode.FILE_UPLOAD_FAILED);
+        }
     }
 
     @Override
     public String generatePresignedDownloadUrl(String s3Key, int expiryMinutes) {
-        throw new UnsupportedOperationException("로컬 환경에서는 presigned URL을 지원하지 않습니다.");
+        return baseUrl + "/uploads/" + s3Key;
     }
 
     private String getExtension(String originalFilename) {

--- a/src/main/java/com/sashimi/global/storage/S3FileStorageAdapter.java
+++ b/src/main/java/com/sashimi/global/storage/S3FileStorageAdapter.java
@@ -3,6 +3,8 @@ package com.sashimi.global.storage;
 import com.sashimi.global.exception.BusinessException;
 import com.sashimi.global.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.annotation.Primary;
 import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Component;
 import org.springframework.web.multipart.MultipartFile;
@@ -17,6 +19,8 @@ import java.time.Duration;
 import java.util.Set;
 import java.util.UUID;
 
+@Slf4j
+@Primary
 @Profile("s3")
 @Component
 @RequiredArgsConstructor
@@ -51,6 +55,7 @@ public class S3FileStorageAdapter implements FileStoragePort {
                     RequestBody.fromBytes(file.getBytes())
             );
         } catch (Exception e) {
+            log.error("[S3] 이미지 업로드 실패 - key: {}, cause: {}", key, e.getMessage(), e);
             throw new BusinessException(ErrorCode.FILE_UPLOAD_FAILED);
         }
 
@@ -70,6 +75,8 @@ public class S3FileStorageAdapter implements FileStoragePort {
                     RequestBody.fromBytes(bytes)
             );
         } catch (Exception e) {
+            log.error("[S3] private 파일 업로드 실패 - bucket: {}, key: {}, cause: {}",
+                    properties.getS3().getBucketDocs(), key, e.getMessage(), e);
             throw new BusinessException(ErrorCode.FILE_UPLOAD_FAILED);
         }
 

--- a/src/main/java/com/sashimi/member/application/service/MemberCommandService.java
+++ b/src/main/java/com/sashimi/member/application/service/MemberCommandService.java
@@ -50,12 +50,30 @@ public class MemberCommandService implements MemberCommandUseCase {
             throw new BusinessException(ErrorCode.CATEGORY_NOT_FOUND);
         }
 
-        // 자격증 OCR 검증 - 성공한 파일들 모두 수집
-        List<InstructorCertification> certifications = command.certificateFiles().stream()
-                .map(f -> ocrPort.extractCertificateInfo(f.fileBytes(), f.fileName()))
-                .filter(OcrPort.OcrResult::success)
-                .map(r -> InstructorCertification.of(r.certificationName(), r.issuedBy()))
-                .collect(Collectors.toList());
+        // 중복 신청 방지 - S3 업로드 전에 체크해야 orphan 파일 방지
+        boolean alreadyApplied = instructorApplicationRepository
+                .existsByUserIdAndApprovalStatus(command.userId(), ApprovalStatus.PENDING);
+        if (alreadyApplied) {
+            throw new BusinessException(ErrorCode.ALREADY_APPLIED);
+        }
+
+        // 자격증 OCR 검증 후 S3 업로드
+        List<InstructorCertification> certifications = new java.util.ArrayList<>();
+        for (ApplyInstructorCommand.FileEntry certFile : command.certificateFiles()) {
+            OcrPort.OcrResult ocrResult = ocrPort.extractCertificateInfo(certFile.fileBytes(), certFile.fileName());
+            if (ocrResult.success()) {
+                String certFileKey = fileStoragePort.storePrivate(
+                        certFile.fileBytes(),
+                        certFile.fileName(),
+                        "instructor-applications/certificates"
+                );
+                certifications.add(InstructorCertification.of(
+                        ocrResult.certificationName(),
+                        ocrResult.issuedBy(),
+                        certFileKey
+                ));
+            }
+        }
 
         if (certifications.isEmpty()) {
             throw new BusinessException(ErrorCode.CERTIFICATE_OCR_FAILED);
@@ -72,13 +90,6 @@ public class MemberCommandService implements MemberCommandUseCase {
                 command.resumeFile().fileBytes());
         if (mainCareers.isEmpty()) {
             throw new BusinessException(ErrorCode.RESUME_PARSE_FAILED);
-        }
-
-        // 중복 신청 방지
-        boolean alreadyApplied = instructorApplicationRepository
-                .existsByUserIdAndApprovalStatus(command.userId(), ApprovalStatus.PENDING);
-        if (alreadyApplied) {
-            throw new BusinessException(ErrorCode.ALREADY_APPLIED);
         }
 
         String profileImageKey = fileStoragePort.storePrivate(

--- a/src/main/java/com/sashimi/member/domain/model/InstructorCertification.java
+++ b/src/main/java/com/sashimi/member/domain/model/InstructorCertification.java
@@ -10,11 +10,13 @@ public class InstructorCertification {
     private Long id;
     private String certificationName;
     private String issuedBy;
+    private String filePath;
 
-    public static InstructorCertification of(String certificationName, String issuedBy) {
+    public static InstructorCertification of(String certificationName, String issuedBy, String filePath) {
         return InstructorCertification.builder()
                 .certificationName(certificationName)
                 .issuedBy(issuedBy)
+                .filePath(filePath)
                 .build();
     }
 }

--- a/src/main/java/com/sashimi/member/infrastructure/persistence/InstructorApplicationJpaEntity.java
+++ b/src/main/java/com/sashimi/member/infrastructure/persistence/InstructorApplicationJpaEntity.java
@@ -126,6 +126,7 @@ public class InstructorApplicationJpaEntity {
                     entity.certifications.add(InstructorCertificationJpaEntity.builder()
                             .certificationName(cert.getCertificationName())
                             .issuedBy(cert.getIssuedBy())
+                            .filePath(cert.getFilePath())
                             .application(entity)
                             .build())
             );

--- a/src/main/java/com/sashimi/member/infrastructure/persistence/InstructorCertificationJpaEntity.java
+++ b/src/main/java/com/sashimi/member/infrastructure/persistence/InstructorCertificationJpaEntity.java
@@ -24,14 +24,18 @@ public class InstructorCertificationJpaEntity {
     @Column(name = "issued_by")
     private String issuedBy;
 
+    @Column(name = "file_path", length = 500)
+    private String filePath;
+
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "instructor_profile_id", nullable = false)
     private InstructorApplicationJpaEntity application;
 
     @Builder
-    public InstructorCertificationJpaEntity(String certificationName, String issuedBy, InstructorApplicationJpaEntity application) {
+    public InstructorCertificationJpaEntity(String certificationName, String issuedBy, String filePath, InstructorApplicationJpaEntity application) {
         this.certificationName = certificationName;
         this.issuedBy = issuedBy;
+        this.filePath = filePath;
         this.application = application;
     }
 
@@ -40,6 +44,7 @@ public class InstructorCertificationJpaEntity {
                 .id(id)
                 .certificationName(certificationName)
                 .issuedBy(issuedBy)
+                .filePath(filePath)
                 .build();
     }
 }

--- a/src/main/resources/db/migration/V2.14__add_file_path_to_instructor_certifications.sql
+++ b/src/main/resources/db/migration/V2.14__add_file_path_to_instructor_certifications.sql
@@ -1,0 +1,2 @@
+ALTER TABLE instructor_application_certifications
+    ADD COLUMN file_path VARCHAR(500) NULL;


### PR DESCRIPTION
## 📌 PR 요약
- 회원가입·개인정보 수정 시 선택 동의 항목(마케팅/이메일/AI)을 DB에 저장하고 수정할 수 있도록 구현했습니다. 또한 강사 지원 시 자격증 파일이 OCR 검증 후 S3에 저장되지 
  않던 문제를 수정하고, 로컬 환경에서도 파일 저장 흐름을 테스트할 수 있도록 LocalFileStorageAdapter를 개선했습니다.

---

## 🛠️ 작업 상세 내용 (체크로 선택)
- [ ] ✨ FEATURE
- [ ] 🔧 UPDATE
- [ ] 🐛 BUGFIX
- [ ] ♻️ REFACTOR
- [ ] 📝 DOCS

---

## 📋 작업 상세 내용
- 
- [DB]                                                                                                                                                                
  - users 테이블에 선택 동의 컬럼 3개 추가 (V2.13)                                                                                                                    
  - instructor_application_certifications에 file_path 컬럼 추가 (V2.14)                                                                                               
                                                                                                                                                                      
  [회원가입 / 개인정보 수정]                                                                                                                                          
  - 회원가입 요청(SignupRequestDto)에 동의 3개 필드 추가, 가입 시 DB 저장                                                                                             
  - 기존 PATCH /users/me에 동의 수정 포함 — 별도 API 추가 없음                                                                                                        
  - GET /users/me 응답에 동의 현재 상태 포함 (프론트 토글 초기값 활용)                                                                                                
                                                                                                                                                                      
  [강사 지원 S3]                                                                                                                                                      
  - 자격증 OCR 통과 후 S3 instructor-applications/certificates/ 경로에 업로드                                                                                         
  - 중복 신청 체크를 S3 업로드 이전으로 이동하여 orphan 파일 생성 방지                                                                                                
  - S3 업로드 실패 시 원인을 알 수 있도록 오류 로그 추가                                                                                                              
                                                                                                                                                                      
  [인프라]                                                                                                                                                            
  - LocalFileStorageAdapter.storePrivate() 로컬 폴더 저장 구현으로 로컬 환경 테스트 가능                                                                              
  - S3FileStorageAdapter에 @Primary 추가로 local,s3 프로필 동시 활성화 시 빈 충돌 해결
- 

---

## 🔗 PR 관련 이슈로 닫기
Closes #266

---

## ✅ 체크리스트 (확인 절차)
- [ ] 정상적으로 빌드 및 실행됩니다.
- [ ] 주요 기능이 정상 동작합니다.
- [ ] 불필요한 코드를 제거했습니다.
- [ ] 코드 리뷰 준비가 완료되었습니다.

---

## 💬 리뷰어에게 할 말
- 

---

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 강사 인증서 파일 저장 기능 추가
  * 파일 저장소에서 일관된 파일 관리 지원

* **개선사항**
  * 파일 업로드 실패 시 상세한 오류 로깅 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->