### PR TITLE
[UPDATE]  #212 강사 신청 반려 이력 조회

### DIFF
--- a/src/main/java/com/sashimi/member/application/service/MemberQueryService.java
+++ b/src/main/java/com/sashimi/member/application/service/MemberQueryService.java
@@ -10,6 +10,7 @@ import com.sashimi.member.presentation.api.response.InstructorApplicationDetailR
 import com.sashimi.member.presentation.api.response.InstructorApplicationListResponse;
 import com.sashimi.member.presentation.api.response.MyInstructorApplicationDetailResponse;
 import com.sashimi.member.presentation.api.response.MyInstructorApplicationListResponse;
+import com.sashimi.member.presentation.api.response.RejectedApplicationListResponse;
 import com.sashimi.user.domain.model.User;
 import com.sashimi.user.domain.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
@@ -63,5 +64,17 @@ public class MemberQueryService implements MemberQueryUseCase {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
         return MyInstructorApplicationDetailResponse.of(application, user);
+    }
+
+    @Override
+    public List<RejectedApplicationListResponse> getRejectedInstructorApplications() {
+        return instructorApplicationRepository.findAllByStatus(ApprovalStatus.REJECTED)
+                .stream()
+                .map(application -> {
+                    User user = userRepository.findById(application.getUserId())
+                            .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
+                    return RejectedApplicationListResponse.of(application, user);
+                })
+                .toList();
     }
 }

--- a/src/main/java/com/sashimi/member/application/usecase/MemberQueryUseCase.java
+++ b/src/main/java/com/sashimi/member/application/usecase/MemberQueryUseCase.java
@@ -4,6 +4,7 @@ import com.sashimi.member.presentation.api.response.InstructorApplicationDetailR
 import com.sashimi.member.presentation.api.response.InstructorApplicationListResponse;
 import com.sashimi.member.presentation.api.response.MyInstructorApplicationDetailResponse;
 import com.sashimi.member.presentation.api.response.MyInstructorApplicationListResponse;
+import com.sashimi.member.presentation.api.response.RejectedApplicationListResponse;
 
 import java.util.List;
 
@@ -16,4 +17,6 @@ public interface MemberQueryUseCase {
     List<MyInstructorApplicationListResponse> getMyInstructorApplications(Long userId);
 
     MyInstructorApplicationDetailResponse getMyInstructorApplicationDetail(Long userId, Long applicationId);
+
+    List<RejectedApplicationListResponse> getRejectedInstructorApplications();
 }

--- a/src/main/java/com/sashimi/member/presentation/MemberController.java
+++ b/src/main/java/com/sashimi/member/presentation/MemberController.java
@@ -9,6 +9,7 @@ import com.sashimi.member.presentation.api.response.InstructorApplicationDetailR
 import com.sashimi.member.presentation.api.response.InstructorApplicationListResponse;
 import com.sashimi.member.presentation.api.response.MyInstructorApplicationDetailResponse;
 import com.sashimi.member.presentation.api.response.MyInstructorApplicationListResponse;
+import com.sashimi.member.presentation.api.response.RejectedApplicationListResponse;
 import jakarta.validation.Valid;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
@@ -157,5 +158,18 @@ public class MemberController {
             @PathVariable Long applicationId) {
         InstructorApplicationDetailResponse response = memberQueryUseCase.getInstructorApplicationDetail(applicationId);
         return ResponseEntity.ok(ApiResponse.of("강사 신청 상세 조회 성공", response));
+    }
+
+    @Operation(summary = "강사 신청 반려 이력 조회 [ADMIN 전용]", description = "관리자만 반려된 강사 신청 이력을 조회할 수 있습니다. ROLE_ADMIN 권한 필요.")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "조회 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "인증 실패"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "권한 없음 (ROLE_ADMIN 아닌 경우)"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "500", description = "서버 오류")
+    })
+    @GetMapping("/instructor-applications/rejected")
+    public ResponseEntity<ApiResponse<List<RejectedApplicationListResponse>>> getRejectedInstructorApplications() {
+        List<RejectedApplicationListResponse> responses = memberQueryUseCase.getRejectedInstructorApplications();
+        return ResponseEntity.ok(ApiResponse.of("강사 신청 반려 이력 조회 성공", responses));
     }
 }

--- a/src/main/java/com/sashimi/member/presentation/api/response/RejectedApplicationListResponse.java
+++ b/src/main/java/com/sashimi/member/presentation/api/response/RejectedApplicationListResponse.java
@@ -1,0 +1,29 @@
+package com.sashimi.member.presentation.api.response;
+
+import com.sashimi.member.domain.model.InstructorApplication;
+import com.sashimi.member.domain.model.RejectionCategory;
+import com.sashimi.user.domain.model.User;
+
+import java.time.LocalDateTime;
+
+public record RejectedApplicationListResponse(
+        Long applicationId,
+        String name,
+        String loginId,
+        String email,
+        LocalDateTime rejectedAt,
+        RejectionCategory rejectionCategory,
+        String rejectionReason
+) {
+    public static RejectedApplicationListResponse of(InstructorApplication application, User user) {
+        return new RejectedApplicationListResponse(
+                application.getId(),
+                user.getName(),
+                user.getLoginId(),
+                user.getEmail(),
+                application.getUpdatedAt(),
+                application.getRejectionCategory(),
+                application.getRejectionReason()
+        );
+    }
+}


### PR DESCRIPTION
## 📌 PR 요약
- 

---

## 🛠️ 작업 상세 내용 (체크로 선택)
- [ ] ✨ FEATURE
- [x] 🔧 UPDATE
- [ ] 🐛 BUGFIX
- [ ] ♻️ REFACTOR
- [ ] 📝 DOCS

---

## 📋 작업 상세 내용
- 관리자가 반려된 강사 신청 목록을 조회하는 API
- GET /api/members/instructor-applications/rejected
-

---

## 🔗 PR 관련 이슈로 닫기
Closes #212 

---

## ✅ 체크리스트 (확인 절차)
- [ ] 정상적으로 빌드 및 실행됩니다.
- [ ] 주요 기능이 정상 동작합니다.
- [ ] 불필요한 코드를 제거했습니다.
- [ ] 코드 리뷰 준비가 완료되었습니다.

---

## 💬 리뷰어에게 할 말
- 이메일/시스템 알림 → 박민서 진행 중

---

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 관리자가 거절된 강사 신청 목록을 조회할 수 있는 기능이 추가되었습니다. 각 신청의 지원자 정보, 거절 시각, 거절 유형 및 사유를 포함한 상세 내역을 확인할 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->