### PR TITLE
[FEATURE] #181 AI 구독권 조회(플랜 목록, 결제 내역, 구독 상태 등) 및 크레딧 결제 기능 추가

### DIFF
--- a/src/main/java/com/sashimi/global/exception/ErrorCode.java
+++ b/src/main/java/com/sashimi/global/exception/ErrorCode.java
@@ -68,6 +68,9 @@ public enum ErrorCode {
     PAYMENT_AGREEMENT_REQUIRED(400, "PAYMENT_009", "결제 진행을 위해 결제 동의가 필요합니다."),
     PAYMENT_COURSE_ID_REQUIRED(400, "PAYMENT_010", "단일 강의 결제에는 강의 ID가 필요합니다."),
     PAYMENT_CART_COURSE_ID_NOT_ALLOWED(400, "PAYMENT_011", "장바구니 결제에는 강의 ID를 전달할 수 없습니다."),
+    PAYMENT_SUBSCRIPTION_PLAN_REQUIRED(400, "PAYMENT_012", "구독권 결제에는 구독 플랜이 필요합니다."),
+    PAYMENT_PLAN_NOT_ALLOWED(400, "PAYMENT_013", "강의 또는 장바구니 결제에는 구독 플랜을 전달할 수 없습니다."),
+    PAYMENT_SUBSCRIPTION_COURSE_ID_NOT_ALLOWED(400, "PAYMENT_014", "구독권 결제에는 강의 ID를 전달할 수 없습니다."),
 
     CREDIT_INVALID_AMOUNT(400, "CREDIT_001", "크레딧 금액이 올바르지 않습니다."),
     CREDIT_INSUFFICIENT_BALANCE(400, "CREDIT_002", "크레딧 잔액이 부족합니다."),

--- a/src/main/java/com/sashimi/order/domain/model/OrderItem.java
+++ b/src/main/java/com/sashimi/order/domain/model/OrderItem.java
@@ -34,6 +34,10 @@ public class OrderItem {
         return new OrderItem(null, OrderItemType.COURSE, courseId, courseTitle, price, 0L, price, orderId, courseId);
     }
 
+    public static OrderItem createSubscription(String planName, Long price, Long orderId, Long subscriptionId) {
+        return new OrderItem(null, OrderItemType.AI_SUBSCRIPTION, subscriptionId, planName, price, 0L, price, orderId, null);
+    }
+
     public static OrderItem restore(Long id, String courseTitle, Long price, Long discountAmount,
                                     Long finalPrice, Long orderId, Long courseId) {
         return new OrderItem(
@@ -73,4 +77,7 @@ public class OrderItem {
     public Long getCourseId() { return courseId; }
     public OrderItemType getItemType() { return itemType; }
     public Long getItemId() { return itemId; }
+
+
+
 }

--- a/src/main/java/com/sashimi/payment/application/command/PaymentCheckoutCommand.java
+++ b/src/main/java/com/sashimi/payment/application/command/PaymentCheckoutCommand.java
@@ -1,10 +1,13 @@
 package com.sashimi.payment.application.command;
 
+import com.sashimi.subscription.domain.model.SubscriptionPlan;
+
 public record PaymentCheckoutCommand(
 
         Long userId,
         PaymentPurchaseType purchaseType,
         Long courseId,
+        SubscriptionPlan planCode,
         Boolean agreed
 
 ) {

--- a/src/main/java/com/sashimi/payment/application/command/PaymentPurchaseType.java
+++ b/src/main/java/com/sashimi/payment/application/command/PaymentPurchaseType.java
@@ -2,5 +2,6 @@ package com.sashimi.payment.application.command;
 
 public enum PaymentPurchaseType {
     COURSE,
-    CART
+    CART,
+    AI_SUBSCRIPTION
 }

--- a/src/main/java/com/sashimi/payment/application/service/PaymentCommandService.java
+++ b/src/main/java/com/sashimi/payment/application/service/PaymentCommandService.java
@@ -1,22 +1,29 @@
 package com.sashimi.payment.application.service;
 
-import com.sashimi.order.application.policy.CoursePurchasePolicy;
 import com.sashimi.cart.application.port.CourseInfo;
 import com.sashimi.cart.domain.model.CartItem;
 import com.sashimi.cart.domain.repository.CartItemRepository;
 import com.sashimi.credit.application.command.UseCreditCommand;
+import com.sashimi.credit.application.result.CreditBalanceResult;
 import com.sashimi.credit.application.usecase.CreditCommandUseCase;
 import com.sashimi.enrollment.application.port.EnrollmentPort;
 import com.sashimi.global.exception.BusinessException;
 import com.sashimi.global.exception.ErrorCode;
-import com.sashimi.payment.application.command.PaymentCheckoutCommand;
-import com.sashimi.payment.application.usecase.PaymentCommandUseCase;
+import com.sashimi.order.application.policy.CoursePurchasePolicy;
 import com.sashimi.order.domain.model.Order;
 import com.sashimi.order.domain.model.OrderItem;
-import com.sashimi.payment.domain.model.Payment;
 import com.sashimi.order.domain.repository.OrderItemRepository;
 import com.sashimi.order.domain.repository.OrderRepository;
+import com.sashimi.payment.application.command.PaymentCheckoutCommand;
+import com.sashimi.payment.application.command.PaymentPurchaseType;
+import com.sashimi.payment.application.usecase.PaymentCommandUseCase;
+import com.sashimi.payment.domain.model.Payment;
 import com.sashimi.payment.domain.repository.PaymentRepository;
+import com.sashimi.subscription.domain.model.Subscription;
+import com.sashimi.subscription.domain.model.SubscriptionPayment;
+import com.sashimi.subscription.domain.model.SubscriptionPlan;
+import com.sashimi.subscription.domain.repository.SubscriptionPaymentRepository;
+import com.sashimi.subscription.domain.repository.SubscriptionRepository;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -29,7 +36,8 @@ import java.util.UUID;
 @Slf4j
 @Service
 @Transactional
-public class PaymentCommandService implements PaymentCommandUseCase {
+public class PaymentCommandService
+        implements PaymentCommandUseCase {
 
     private final CartItemRepository cartItemRepository;
     private final CoursePurchasePolicy coursePurchasePolicy;
@@ -38,6 +46,9 @@ public class PaymentCommandService implements PaymentCommandUseCase {
     private final OrderItemRepository orderItemRepository;
     private final PaymentRepository paymentRepository;
     private final CreditCommandUseCase creditCommandUseCase;
+    private final SubscriptionRepository subscriptionRepository;
+    private final SubscriptionPaymentRepository
+            subscriptionPaymentRepository;
 
     public PaymentCommandService(
             CartItemRepository cartItemRepository,
@@ -46,7 +57,10 @@ public class PaymentCommandService implements PaymentCommandUseCase {
             OrderRepository orderRepository,
             OrderItemRepository orderItemRepository,
             PaymentRepository paymentRepository,
-            CreditCommandUseCase creditCommandUseCase
+            CreditCommandUseCase creditCommandUseCase,
+            SubscriptionRepository subscriptionRepository,
+            SubscriptionPaymentRepository
+                    subscriptionPaymentRepository
     ) {
         this.cartItemRepository = cartItemRepository;
         this.coursePurchasePolicy = coursePurchasePolicy;
@@ -55,110 +69,184 @@ public class PaymentCommandService implements PaymentCommandUseCase {
         this.orderItemRepository = orderItemRepository;
         this.paymentRepository = paymentRepository;
         this.creditCommandUseCase = creditCommandUseCase;
+        this.subscriptionRepository = subscriptionRepository;
+        this.subscriptionPaymentRepository =
+                subscriptionPaymentRepository;
     }
 
     @Override
-    public PaymentResult checkout(PaymentCheckoutCommand command) {
+    public PaymentResult checkout(
+            PaymentCheckoutCommand command
+    ) {
         if (!Boolean.TRUE.equals(command.agreed())) {
-            throw new BusinessException(ErrorCode.PAYMENT_AGREEMENT_REQUIRED);
+            throw new BusinessException(
+                    ErrorCode.PAYMENT_AGREEMENT_REQUIRED);
         }
 
         if (command.purchaseType() == null) {
-            throw new BusinessException(ErrorCode.PAYMENT_INVALID_CHECKOUT_REQUEST);
+            throw new BusinessException(
+                    ErrorCode.PAYMENT_INVALID_CHECKOUT_REQUEST);
         }
 
         return switch (command.purchaseType()) {
-            case COURSE -> checkoutCourse(command.userId(), command.courseId());
-            case CART -> checkoutCart(command.userId(), command.courseId());
+            case COURSE -> {
+                validateCourseRequest(command);
+
+                yield checkoutCourse(
+                        command.userId(),
+                        command.courseId());
+            }
+
+            case CART -> {
+                validateCartRequest(command);
+
+                yield checkoutCart(command.userId());
+            }
+
+            case AI_SUBSCRIPTION -> {
+                validateSubscriptionRequest(command);
+
+                yield checkoutSubscription(
+                        command.userId(),
+                        command.planCode());
+            }
         };
     }
 
-    private PaymentResult checkoutCourse(Long userId, Long courseId) {
-        if (courseId == null || courseId <= 0) {
-            throw new BusinessException(ErrorCode.PAYMENT_COURSE_ID_REQUIRED);
+    private void validateCourseRequest(
+            PaymentCheckoutCommand command
+    ) {
+        if (command.courseId() == null
+                || command.courseId() <= 0) {
+            throw new BusinessException(
+                    ErrorCode.PAYMENT_COURSE_ID_REQUIRED);
         }
 
-        CourseInfo course = coursePurchasePolicy.validatePurchasable(userId, courseId);
+        if (command.planCode() != null) {
+            throw new BusinessException(
+                    ErrorCode.PAYMENT_PLAN_NOT_ALLOWED);
+        }
+    }
 
-        PaymentResult result = pay(userId, List.of(
-                new PaymentCourse(course.courseId(), course.title(), course.price())
-        ), PaymentSource.DIRECT);
+    private void validateCartRequest(
+            PaymentCheckoutCommand command
+    ) {
+        if (command.courseId() != null) {
+            throw new BusinessException(
+                    ErrorCode.PAYMENT_CART_COURSE_ID_NOT_ALLOWED);
+        }
+
+        if (command.planCode() != null) {
+            throw new BusinessException(
+                    ErrorCode.PAYMENT_PLAN_NOT_ALLOWED);
+        }
+    }
+
+    private void validateSubscriptionRequest(
+            PaymentCheckoutCommand command
+    ) {
+        if (command.courseId() != null) {
+            throw new BusinessException(
+                    ErrorCode
+                            .PAYMENT_SUBSCRIPTION_COURSE_ID_NOT_ALLOWED);
+        }
+
+        if (command.planCode() == null) {
+            throw new BusinessException(
+                    ErrorCode.PAYMENT_SUBSCRIPTION_PLAN_REQUIRED);
+        }
+    }
+
+    private PaymentResult checkoutCourse(Long userId, Long courseId) {
+        CourseInfo course =
+                coursePurchasePolicy.validatePurchasable(
+                        userId,
+                        courseId);
+
+        PaymentResult result = payCourses(
+                userId,
+                List.of(
+                        new PaymentCourse(
+                                course.courseId(),
+                                course.title(),
+                                course.price())
+                ),
+                PaymentSource.DIRECT);
 
         cartItemRepository.deleteByUserIdAndCourseId(userId, courseId);
+
         return result;
     }
 
-    private PaymentResult checkoutCart(Long userId, Long courseId) {
-        if (courseId != null) {
-            throw new BusinessException(ErrorCode.PAYMENT_CART_COURSE_ID_NOT_ALLOWED);
-        }
-
-        List<CartItem> cartItems = cartItemRepository.findAllSelectedByUserId(userId);
+    private PaymentResult checkoutCart(Long userId) {
+        List<CartItem> cartItems =
+                cartItemRepository.findAllSelectedByUserId(
+                        userId);
 
         if (cartItems.isEmpty()) {
-            throw new BusinessException(ErrorCode.CART_EMPTY_SELECTION);
+            throw new BusinessException(
+                    ErrorCode.CART_EMPTY_SELECTION);
         }
 
-        List<PaymentCourse> courses = cartItems.stream()
-                .map(item -> coursePurchasePolicy.validatePurchasable(
-                        userId, item.getCourseId()
-                ))
-                .map(course -> new PaymentCourse(
-                        course.courseId(), course.title(), course.price()
-                ))
+        List<PaymentCourse> courses = cartItems.stream().map(item -> coursePurchasePolicy.validatePurchasable(
+                userId, item.getCourseId()))
+                .map(course -> new PaymentCourse(course.courseId(), course.title(), course.price()))
                 .toList();
-
-        return pay(userId, courses, PaymentSource.CART);
+        return payCourses(userId, courses, PaymentSource.CART);
     }
 
-    private PaymentResult pay(Long userId, List<PaymentCourse> courses, PaymentSource source) {
+    private PaymentResult payCourses(
+            Long userId,
+            List<PaymentCourse> courses,
+            PaymentSource source
+    ) {
         if (courses == null || courses.isEmpty()) {
-            throw new BusinessException(ErrorCode.PAYMENT_EMPTY_COURSE);
+            throw new BusinessException(
+                    ErrorCode.PAYMENT_EMPTY_COURSE);
         }
 
-        Long totalAmount = courses.stream()
-                .mapToLong(PaymentCourse::price)
-                .sum();
+        long totalAmount = courses.stream().mapToLong(PaymentCourse::price).sum();
 
-        Order order = orderRepository.save(Order.paid(createOrderNo(), totalAmount, userId));
+        Order order = orderRepository.save(Order.paid(createOrderNo(), totalAmount, userId) );
 
-        log.info("주문 생성 완료 - userId={}, orderId={}, orderNo={}, totalAmount={}",
-                userId, order.getId(), order.getOrderNo(), totalAmount);
-
-        List<OrderItem> orderItems = courses.stream()
-                .map(course -> orderItemRepository.save(
-                        OrderItem.createCourse(course.title(), course.price(), order.getId(), course.courseId())
-                ))
-                .toList();
+        List<OrderItem> orderItems = courses.stream().map(course -> orderItemRepository.save(
+                OrderItem.createCourse(course.title(), course.price(), order.getId(), course.courseId()))).toList();
 
         Payment payment = paymentRepository.save(Payment.paid(totalAmount, order.getId(), userId));
 
-        completePayment(userId, payment, orderItems, source);
+        long creditBalance = completeCoursePayment(userId, payment, orderItems, source);
 
-        log.info("결제 완료 처리 완료 - userId={}, orderId={}, paymentId={}, amount={}, courseCount={}",
-                userId, order.getId(), payment.getId(), payment.getAmount(), orderItems.size());
+        PaymentPurchaseType purchaseType =
+                source == PaymentSource.CART
+                        ? PaymentPurchaseType.CART
+                        : PaymentPurchaseType.COURSE;
 
-        return new PaymentResult(
+        log.info("강의 결제 완료 - userId={}, orderId={}, paymentId={}, amount={}, courseCount={}",
+                userId,
                 order.getId(),
-                order.getOrderNo(),
                 payment.getId(),
                 payment.getAmount(),
-                payment.getStatus().name(),
-                orderItems.stream()
-                        .map(item -> new PaidCourse(item.getCourseId(), item.getCourseTitle(), item.getFinalPrice()))
-                        .toList()
+                orderItems.size()
         );
+
+        return new PaymentResult(order.getId(), order.getOrderNo(), payment.getId(), purchaseType, payment.getAmount(), payment.getStatus().name(), creditBalance, orderItems.stream()
+                        .map(item ->
+                                new PaidCourse(item.getCourseId(), item.getCourseTitle(), item.getFinalPrice())).toList(), null);
     }
 
-    private void completePayment(
+    private long completeCoursePayment(
             Long userId,
             Payment payment,
             List<OrderItem> orderItems,
             PaymentSource source
     ) {
-        creditCommandUseCase.useCredit(
-                new UseCreditCommand(userId, payment.getAmount())
-        );
+        CreditBalanceResult credit =
+                creditCommandUseCase.useCredit(
+                        new UseCreditCommand(
+                                userId,
+                                payment.getAmount()
+                        )
+                );
 
         for (OrderItem orderItem : orderItems) {
             enrollmentPort.enrollPaidCourse(
@@ -169,13 +257,126 @@ public class PaymentCommandService implements PaymentCommandUseCase {
         }
 
         if (source == PaymentSource.CART) {
-            cartItemRepository.deleteAllSelectedByUserId(userId);
+            cartItemRepository
+                    .deleteAllSelectedByUserId(userId);
         }
+
+        return credit.balance();
+    }
+
+    private PaymentResult checkoutSubscription(
+            Long userId,
+            SubscriptionPlan plan
+    ) {
+        LocalDateTime now = LocalDateTime.now();
+
+        if (subscriptionRepository.findActiveByUserId(
+                userId,
+                now
+        ).isPresent()) {
+            throw new BusinessException(
+                    ErrorCode.SUBSCRIPTION_ALREADY_ACTIVE
+            );
+        }
+
+        Order order = orderRepository.save(
+                Order.paid(
+                        createOrderNo(),
+                        plan.getPrice(),
+                        userId
+                )
+        );
+
+        Subscription subscription =
+                subscriptionRepository.save(
+                        Subscription.start(
+                                userId,
+                                plan,
+                                now
+                        )
+                );
+
+        orderItemRepository.save(
+                OrderItem.createSubscription(
+                        plan.getPlanName(),
+                        plan.getPrice(),
+                        order.getId(),
+                        subscription.getId()
+                )
+        );
+
+        Payment payment = paymentRepository.save(
+                Payment.paid(
+                        plan.getPrice(),
+                        order.getId(),
+                        userId
+                )
+        );
+
+        CreditBalanceResult credit =
+                creditCommandUseCase.useCredit(
+                        new UseCreditCommand(
+                                userId,
+                                payment.getAmount()
+                        )
+                );
+
+        subscriptionPaymentRepository.save(
+                SubscriptionPayment.initial(
+                        subscription.getId(),
+                        order.getId(),
+                        payment.getId(),
+                        userId,
+                        order.getOrderNo(),
+                        plan,
+                        payment.getAmount(),
+                        payment.getPaidAt()
+                )
+        );
+
+        log.info(
+                "AI 구독권 결제 완료 - userId={}, subscriptionId={}, orderId={}, paymentId={}, plan={}, amount={}",
+                userId,
+                subscription.getId(),
+                order.getId(),
+                payment.getId(),
+                plan.name(),
+                payment.getAmount()
+        );
+
+        return new PaymentResult(
+                order.getId(),
+                order.getOrderNo(),
+                payment.getId(),
+                PaymentPurchaseType.AI_SUBSCRIPTION,
+                payment.getAmount(),
+                payment.getStatus().name(),
+                credit.balance(),
+                List.of(),
+                new PaidSubscription(
+                        subscription.getId(),
+                        plan.name(),
+                        plan.getPlanName(),
+                        subscription.getStatus().name(),
+                        subscription.getStartedAt(),
+                        subscription.getExpiredAt(),
+                        subscription.getNextBillingAt()
+                )
+        );
     }
 
     private String createOrderNo() {
-        return "ORD-" + LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyyMMddHHmmssSSS"))
-                + "-" + UUID.randomUUID().toString().substring(0, 8).toUpperCase();
+        return "ORD-"
+                + LocalDateTime.now().format(
+                DateTimeFormatter.ofPattern(
+                        "yyyyMMddHHmmssSSS"
+                )
+        )
+                + "-"
+                + UUID.randomUUID()
+                .toString()
+                .substring(0, 8)
+                .toUpperCase();
     }
 
     private enum PaymentSource {
@@ -183,6 +384,10 @@ public class PaymentCommandService implements PaymentCommandUseCase {
         DIRECT
     }
 
-    private record PaymentCourse(Long courseId, String title, Long price) {
+    private record PaymentCourse(
+            Long courseId,
+            String title,
+            Long price
+    ) {
     }
 }

--- a/src/main/java/com/sashimi/payment/application/service/PaymentQueryService.java
+++ b/src/main/java/com/sashimi/payment/application/service/PaymentQueryService.java
@@ -42,12 +42,24 @@ public class PaymentQueryService implements PaymentQueryUseCase {
 
     @Override
     public PaymentHistory getPaymentHistory(Long userId) {
-        List<PaymentHistoryItem> items = paymentRepository.findAllByUserId(userId)
-                .stream()
-                .map(this::toHistoryItem)
-                .toList();
+        List<PaymentHistoryItem> items =
+                paymentRepository.findAllByUserId(userId)
+                        .stream()
+                        .filter(this::isCoursePayment)
+                        .map(this::toHistoryItem)
+                        .toList();
 
         return new PaymentHistory(items);
+    }
+
+    private boolean isCoursePayment(Payment payment) {
+        return orderItemRepository
+                .findAllByOrderId(payment.getOrderId())
+                .stream()
+                .anyMatch(orderItem ->
+                        orderItem.getItemType()
+                                == OrderItemType.COURSE
+                );
     }
 
     private PaymentHistoryItem toHistoryItem(Payment payment) {

--- a/src/main/java/com/sashimi/payment/application/usecase/PaymentCommandUseCase.java
+++ b/src/main/java/com/sashimi/payment/application/usecase/PaymentCommandUseCase.java
@@ -1,21 +1,27 @@
 package com.sashimi.payment.application.usecase;
 
-
 import com.sashimi.payment.application.command.PaymentCheckoutCommand;
+import com.sashimi.payment.application.command.PaymentPurchaseType;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 public interface PaymentCommandUseCase {
 
-    PaymentResult checkout(PaymentCheckoutCommand command);
+    PaymentResult checkout(
+            PaymentCheckoutCommand command
+    );
 
     record PaymentResult(
             Long orderId,
             String orderNo,
             Long paymentId,
+            PaymentPurchaseType purchaseType,
             Long amount,
             String status,
-            List<PaidCourse> courses
+            Long creditBalance,
+            List<PaidCourse> courses,
+            PaidSubscription subscription
     ) {
     }
 
@@ -23,6 +29,17 @@ public interface PaymentCommandUseCase {
             Long courseId,
             String title,
             Long price
+    ) {
+    }
+
+    record PaidSubscription(
+            Long subscriptionId,
+            String planCode,
+            String planName,
+            String status,
+            LocalDateTime startedAt,
+            LocalDateTime expiresAt,
+            LocalDateTime nextBillingAt
     ) {
     }
 }

--- a/src/main/java/com/sashimi/payment/presentation/api/PaymentController.java
+++ b/src/main/java/com/sashimi/payment/presentation/api/PaymentController.java
@@ -118,12 +118,15 @@ public class PaymentController {
     }
 
     @Operation(
-            summary = "강의 결제",
+            summary = "공통 결제",
             description = """
-                    단일 강의 또는 장바구니에서 선택한 강의를 크레딧으로 결제합니다.
-                    COURSE 결제는 courseId가 필수이고,
-                    CART 결제는 courseId를 전달하지 않아야 합니다.
-                    """
+                단일 강의, 장바구니 선택 강의 또는 AI 구독권을
+                사용자의 크레딧으로 결제합니다.
+
+                COURSE 결제는 courseId가 필수입니다.
+                CART 결제는 courseId와 planCode를 전달하지 않습니다.
+                AI_SUBSCRIPTION 결제는 planCode가 필수입니다.
+                """
     )
     @ApiResponses({
             @ApiResponse(
@@ -163,6 +166,7 @@ public class PaymentController {
                                 principal.getId(),
                                 request.purchaseType(),
                                 request.courseId(),
+                                request.planCode(),
                                 request.agreed()
                         )
                 );

--- a/src/main/java/com/sashimi/payment/presentation/api/request/PaymentCheckoutRequest.java
+++ b/src/main/java/com/sashimi/payment/presentation/api/request/PaymentCheckoutRequest.java
@@ -1,6 +1,7 @@
 package com.sashimi.payment.presentation.api.request;
 
 import com.sashimi.payment.application.command.PaymentPurchaseType;
+import com.sashimi.subscription.domain.model.SubscriptionPlan;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.AssertTrue;
 import jakarta.validation.constraints.NotNull;
@@ -9,15 +10,19 @@ import jakarta.validation.constraints.Positive;
 public record PaymentCheckoutRequest(
 
         @Schema(
-                description = "구매 유형",
-                example = "COURSE",
-                allowableValues = {"COURSE", "CART"}
+                description = "결제 상품 유형",
+                example = "AI_SUBSCRIPTION",
+                allowableValues = {
+                        "COURSE",
+                        "CART",
+                        "AI_SUBSCRIPTION"
+                }
         )
-        @NotNull(message = "구매 유형은 필수입니다.")
+        @NotNull(message = "결제 상품 유형은 필수입니다.")
         PaymentPurchaseType purchaseType,
 
         @Schema(
-                description = "단일 구매할 강의 ID. COURSE일 때 필수이며 CART일 때는 전달하지 않습니다.",
+                description = "단일 강의 결제 시 강의 ID",
                 example = "10",
                 nullable = true
         )
@@ -25,11 +30,24 @@ public record PaymentCheckoutRequest(
         Long courseId,
 
         @Schema(
-                description = "결제 약관 동의 여부. 반드시 true여야 합니다.",
+                description = "AI 구독권 결제 시 플랜 코드",
+                example = "MONTHLY",
+                allowableValues = {
+                        "MONTHLY",
+                        "ANNUAL"
+                },
+                nullable = true
+        )
+        SubscriptionPlan planCode,
+
+        @Schema(
+                description = "결제 약관 동의 여부",
                 example = "true"
         )
         @NotNull(message = "결제 동의 여부는 필수입니다.")
-        @AssertTrue(message = "결제 진행을 위해 결제 동의가 필요합니다.")
+        @AssertTrue(
+                message = "결제 진행을 위해 결제 동의가 필요합니다."
+        )
         Boolean agreed
 ) {
 }

--- a/src/main/java/com/sashimi/payment/presentation/api/response/PaidSubscriptionResponse.java
+++ b/src/main/java/com/sashimi/payment/presentation/api/response/PaidSubscriptionResponse.java
@@ -1,0 +1,44 @@
+package com.sashimi.payment.presentation.api.response;
+
+import com.sashimi.payment.application.usecase.PaymentCommandUseCase;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.time.LocalDateTime;
+
+public record PaidSubscriptionResponse(
+
+        @Schema(description = "구독 ID")
+        Long subscriptionId,
+
+        @Schema(description = "플랜 코드")
+        String planCode,
+
+        @Schema(description = "플랜명")
+        String planName,
+
+        @Schema(description = "구독 상태")
+        String status,
+
+        @Schema(description = "구독 시작일")
+        LocalDateTime startedAt,
+
+        @Schema(description = "구독 만료 예정일")
+        LocalDateTime expiresAt,
+
+        @Schema(description = "다음 자동 결제 예정일")
+        LocalDateTime nextBillingAt
+) {
+    public static PaidSubscriptionResponse from(
+            PaymentCommandUseCase.PaidSubscription result
+    ) {
+        return new PaidSubscriptionResponse(
+                result.subscriptionId(),
+                result.planCode(),
+                result.planName(),
+                result.status(),
+                result.startedAt(),
+                result.expiresAt(),
+                result.nextBillingAt()
+        );
+    }
+}

--- a/src/main/java/com/sashimi/payment/presentation/api/response/PaymentResponse.java
+++ b/src/main/java/com/sashimi/payment/presentation/api/response/PaymentResponse.java
@@ -1,25 +1,66 @@
 package com.sashimi.payment.presentation.api.response;
 
+import com.sashimi.payment.application.command.PaymentPurchaseType;
 import com.sashimi.payment.application.usecase.PaymentCommandUseCase;
+import io.swagger.v3.oas.annotations.media.Schema;
 
 import java.util.List;
 
 public record PaymentResponse(
+
+        @Schema(description = "내부 주문 ID")
         Long orderId,
+
+        @Schema(description = "사용자 표시 주문번호")
         String orderNo,
+
+        @Schema(description = "내부 결제 ID")
         Long paymentId,
+
+        @Schema(description = "결제 상품 유형")
+        PaymentPurchaseType purchaseType,
+
+        @Schema(description = "실제 차감 크레딧")
         Long amount,
+
+        @Schema(description = "결제 상태")
         String status,
-        List<PaidCourseResponse> courses
+
+        @Schema(description = "결제 후 크레딧 잔액")
+        Long creditBalance,
+
+        @Schema(description = "구매 완료 강의 목록")
+        List<PaidCourseResponse> courses,
+
+        @Schema(
+                description = "구독권 결제 결과",
+                nullable = true
+        )
+        PaidSubscriptionResponse subscription
 ) {
-    public static PaymentResponse from(PaymentCommandUseCase.PaymentResult result) {
+    public static PaymentResponse from(
+            PaymentCommandUseCase.PaymentResult result
+    ) {
+        PaidSubscriptionResponse subscriptionResponse =
+                result.subscription() == null
+                        ? null
+                        : PaidSubscriptionResponse.from(
+                        result.subscription()
+                );
+
         return new PaymentResponse(
                 result.orderId(),
                 result.orderNo(),
                 result.paymentId(),
+                result.purchaseType(),
                 result.amount(),
                 result.status(),
-                result.courses().stream().map(PaidCourseResponse::from).toList()
+                result.creditBalance(),
+                result.courses()
+                        .stream()
+                        .map(PaidCourseResponse::from)
+                        .toList(),
+                subscriptionResponse
         );
     }
 }

--- a/src/main/java/com/sashimi/subscription/application/service/SubscriptionQueryService.java
+++ b/src/main/java/com/sashimi/subscription/application/service/SubscriptionQueryService.java
@@ -1,0 +1,190 @@
+package com.sashimi.subscription.application.service;
+
+import com.sashimi.credit.application.usecase.CreditQueryUseCase;
+import com.sashimi.global.exception.BusinessException;
+import com.sashimi.global.exception.ErrorCode;
+import com.sashimi.subscription.application.usecase.SubscriptionQueryUseCase;
+import com.sashimi.subscription.domain.model.SubscriptionPlan;
+import com.sashimi.subscription.domain.repository.SubscriptionPaymentRepository;
+import com.sashimi.subscription.domain.repository.SubscriptionRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Locale;
+
+@Service
+@Transactional(readOnly = true)
+public class SubscriptionQueryService
+        implements SubscriptionQueryUseCase {
+
+    private final SubscriptionRepository subscriptionRepository;
+    private final SubscriptionPaymentRepository subscriptionPaymentRepository;
+    private final CreditQueryUseCase creditQueryUseCase;
+
+    public SubscriptionQueryService(
+            SubscriptionRepository subscriptionRepository,
+            SubscriptionPaymentRepository subscriptionPaymentRepository,
+            CreditQueryUseCase creditQueryUseCase
+    ) {
+        this.subscriptionRepository = subscriptionRepository;
+        this.subscriptionPaymentRepository =
+                subscriptionPaymentRepository;
+        this.creditQueryUseCase = creditQueryUseCase;
+    }
+
+    @Override
+    public List<PlanResult> getPlans() {
+        return Arrays.stream(SubscriptionPlan.values())
+                .map(this::toPlanResult)
+                .toList();
+    }
+
+    @Override
+    public PreviewResult getPreview(
+            Long userId,
+            String planCode
+    ) {
+        SubscriptionPlan plan = parsePlan(planCode);
+
+        long creditBalance =
+                creditQueryUseCase.getBalance(userId).balance();
+
+        boolean alreadySubscribed =
+                subscriptionRepository.findActiveByUserId(
+                        userId,
+                        LocalDateTime.now()
+                ).isPresent();
+
+        long balanceAfterPayment =
+                Math.max(creditBalance - plan.getPrice(), 0L);
+
+        long insufficientAmount =
+                Math.max(plan.getPrice() - creditBalance, 0L);
+
+        boolean purchasable =
+                !alreadySubscribed
+                        && insufficientAmount == 0L;
+
+        return new PreviewResult(
+                toPlanResult(plan),
+                creditBalance,
+                balanceAfterPayment,
+                insufficientAmount,
+                alreadySubscribed,
+                purchasable
+        );
+    }
+
+    @Override
+    public MySubscriptionResult getMySubscription(
+            Long userId
+    ) {
+        return subscriptionRepository.findActiveByUserId(
+                        userId,
+                        LocalDateTime.now()
+                )
+                .map(subscription ->
+                        new MySubscriptionResult(
+                                true,
+                                subscription.getId(),
+                                subscription.getPlan().name(),
+                                subscription.getPlan().getPlanName(),
+                                subscription.getStatus().name(),
+                                subscription.getStartedAt(),
+                                subscription.getExpiredAt(),
+                                subscription.getNextBillingAt(),
+                                subscription.isAutoRenew(),
+                                subscription.isAutoRenew()
+                        )
+                )
+                .orElseGet(() ->
+                        new MySubscriptionResult(
+                                false,
+                                null,
+                                null,
+                                null,
+                                null,
+                                null,
+                                null,
+                                null,
+                                false,
+                                false
+                        )
+                );
+    }
+
+    @Override
+    public PaymentHistoryResult getPaymentHistory(
+            Long userId,
+            int page,
+            int size
+    ) {
+        SubscriptionPaymentRepository.PageResult result =
+                subscriptionPaymentRepository.findAllByUserId(
+                        userId,
+                        page,
+                        size
+                );
+
+        List<PaymentHistoryItem> items =
+                result.content()
+                        .stream()
+                        .map(payment ->
+                                new PaymentHistoryItem(
+                                        payment.getId(),
+                                        payment.getSubscriptionId(),
+                                        payment.getOrderId(),
+                                        payment.getOrderNo(),
+                                        payment.getPlan().name(),
+                                        payment.getPlan().getPlanName(),
+                                        payment.getAmount(),
+                                        payment.getBillingType().name(),
+                                        payment.getPaidAt()
+                                )
+                        )
+                        .toList();
+
+        return new PaymentHistoryResult(
+                items,
+                result.totalElements(),
+                result.totalPages(),
+                result.page(),
+                result.size()
+        );
+    }
+
+    private SubscriptionPlan parsePlan(String planCode) {
+        if (planCode == null || planCode.isBlank()) {
+            throw new BusinessException(
+                    ErrorCode.SUBSCRIPTION_INVALID_PLAN
+            );
+        }
+
+        try {
+            return SubscriptionPlan.valueOf(
+                    planCode.toUpperCase(Locale.ROOT)
+            );
+        } catch (IllegalArgumentException exception) {
+            throw new BusinessException(
+                    ErrorCode.SUBSCRIPTION_INVALID_PLAN
+            );
+        }
+    }
+
+    private PlanResult toPlanResult(
+            SubscriptionPlan plan
+    ) {
+        return new PlanResult(
+                plan.name(),
+                plan.getPlanName(),
+                plan.getDurationMonths(),
+                plan.getOriginalPrice(),
+                plan.getPrice(),
+                plan.getDiscountRate(),
+                plan.getFeatures()
+        );
+    }
+}

--- a/src/main/java/com/sashimi/subscription/application/usecase/SubscriptionQueryUseCase.java
+++ b/src/main/java/com/sashimi/subscription/application/usecase/SubscriptionQueryUseCase.java
@@ -1,0 +1,72 @@
+package com.sashimi.subscription.application.usecase;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public interface SubscriptionQueryUseCase {
+
+    List<PlanResult> getPlans();
+
+    PreviewResult getPreview(Long userId, String planCode);
+
+    MySubscriptionResult getMySubscription(Long userId);
+
+    PaymentHistoryResult getPaymentHistory(Long userId, int page, int size);
+
+    record PlanResult(
+            String planCode,
+            String planName,
+            int durationMonths,
+            Long originalPrice,
+            Long price,
+            int discountRate,
+            List<String> features
+    ) {
+    }
+
+    record PreviewResult(
+            PlanResult plan,
+            Long creditBalance,
+            Long balanceAfterPayment,
+            Long insufficientAmount,
+            boolean alreadySubscribed,
+            boolean purchasable
+    ) {
+    }
+
+    record MySubscriptionResult(
+            boolean subscribed,
+            Long subscriptionId,
+            String planCode,
+            String planName,
+            String status,
+            LocalDateTime startedAt,
+            LocalDateTime expiresAt,
+            LocalDateTime nextBillingAt,
+            boolean autoRenew,
+            boolean cancellable
+    ) {
+    }
+
+    record PaymentHistoryResult(
+            List<PaymentHistoryItem> items,
+            long totalElements,
+            int totalPages,
+            int page,
+            int size
+    ) {
+    }
+
+    record PaymentHistoryItem(
+            Long subscriptionPaymentId,
+            Long subscriptionId,
+            Long orderId,
+            String orderNo,
+            String planCode,
+            String planName,
+            Long amount,
+            String billingType,
+            LocalDateTime paidAt
+    ) {
+    }
+}

--- a/src/main/java/com/sashimi/subscription/domain/model/Subscription.java
+++ b/src/main/java/com/sashimi/subscription/domain/model/Subscription.java
@@ -1,0 +1,99 @@
+package com.sashimi.subscription.domain.model;
+
+import java.time.LocalDateTime;
+
+public class Subscription {
+
+    private final Long id;
+    private final SubscriptionPlan plan;
+    private final SubscriptionStatus status;
+    private final Long price;
+    private final LocalDateTime startedAt;
+    private final LocalDateTime expiredAt;
+    private final LocalDateTime nextBillingAt;
+    private final boolean autoRenew;
+    private final Long userId;
+
+    private Subscription(
+            Long id,
+            SubscriptionPlan plan,
+            SubscriptionStatus status,
+            Long price,
+            LocalDateTime startedAt,
+            LocalDateTime expiredAt,
+            LocalDateTime nextBillingAt,
+            boolean autoRenew,
+            Long userId
+    ) {
+        this.id = id;
+        this.plan = plan;
+        this.status = status;
+        this.price = price;
+        this.startedAt = startedAt;
+        this.expiredAt = expiredAt;
+        this.nextBillingAt = nextBillingAt;
+        this.autoRenew = autoRenew;
+        this.userId = userId;
+    }
+
+    public static Subscription start(
+            Long userId,
+            SubscriptionPlan plan,
+            LocalDateTime startedAt
+    ) {
+        LocalDateTime expiredAt =
+                plan.calculateExpiration(startedAt);
+
+        return new Subscription(
+                null,
+                plan,
+                SubscriptionStatus.ACTIVE,
+                plan.getPrice(),
+                startedAt,
+                expiredAt,
+                expiredAt,
+                true,
+                userId
+        );
+    }
+
+    public static Subscription restore(
+            Long id,
+            SubscriptionPlan plan,
+            SubscriptionStatus status,
+            Long price,
+            LocalDateTime startedAt,
+            LocalDateTime expiredAt,
+            LocalDateTime nextBillingAt,
+            boolean autoRenew,
+            Long userId
+    ) {
+        return new Subscription(
+                id,
+                plan,
+                status,
+                price,
+                startedAt,
+                expiredAt,
+                nextBillingAt,
+                autoRenew,
+                userId
+        );
+    }
+
+    public boolean isActive(LocalDateTime now) {
+        return status == SubscriptionStatus.ACTIVE
+                && expiredAt != null
+                && expiredAt.isAfter(now);
+    }
+
+    public Long getId() { return id; }
+    public SubscriptionPlan getPlan() { return plan; }
+    public SubscriptionStatus getStatus() { return status; }
+    public Long getPrice() { return price; }
+    public LocalDateTime getStartedAt() { return startedAt; }
+    public LocalDateTime getExpiredAt() { return expiredAt; }
+    public LocalDateTime getNextBillingAt() { return nextBillingAt; }
+    public boolean isAutoRenew() { return autoRenew; }
+    public Long getUserId() { return userId; }
+}

--- a/src/main/java/com/sashimi/subscription/domain/model/SubscriptionBillingType.java
+++ b/src/main/java/com/sashimi/subscription/domain/model/SubscriptionBillingType.java
@@ -1,0 +1,6 @@
+package com.sashimi.subscription.domain.model;
+
+public enum SubscriptionBillingType {
+    INITIAL,
+    RENEWAL
+}

--- a/src/main/java/com/sashimi/subscription/domain/model/SubscriptionPayment.java
+++ b/src/main/java/com/sashimi/subscription/domain/model/SubscriptionPayment.java
@@ -1,0 +1,109 @@
+package com.sashimi.subscription.domain.model;
+
+import java.time.LocalDateTime;
+
+public class SubscriptionPayment {
+
+    private final Long id;
+    private final Long subscriptionId;
+    private final Long orderId;
+    private final Long paymentId;
+    private final Long userId;
+    private final String orderNo;
+    private final SubscriptionPlan plan;
+    private final Long amount;
+    private final SubscriptionBillingType billingType;
+    private final LocalDateTime paidAt;
+    private final LocalDateTime createdAt;
+
+    private SubscriptionPayment(
+            Long id,
+            Long subscriptionId,
+            Long orderId,
+            Long paymentId,
+            Long userId,
+            String orderNo,
+            SubscriptionPlan plan,
+            Long amount,
+            SubscriptionBillingType billingType,
+            LocalDateTime paidAt,
+            LocalDateTime createdAt
+    ) {
+        this.id = id;
+        this.subscriptionId = subscriptionId;
+        this.orderId = orderId;
+        this.paymentId = paymentId;
+        this.userId = userId;
+        this.orderNo = orderNo;
+        this.plan = plan;
+        this.amount = amount;
+        this.billingType = billingType;
+        this.paidAt = paidAt;
+        this.createdAt = createdAt;
+    }
+
+    public static SubscriptionPayment initial(
+            Long subscriptionId,
+            Long orderId,
+            Long paymentId,
+            Long userId,
+            String orderNo,
+            SubscriptionPlan plan,
+            Long amount,
+            LocalDateTime paidAt
+    ) {
+        return new SubscriptionPayment(
+                null,
+                subscriptionId,
+                orderId,
+                paymentId,
+                userId,
+                orderNo,
+                plan,
+                amount,
+                SubscriptionBillingType.INITIAL,
+                paidAt,
+                LocalDateTime.now()
+        );
+    }
+
+    public static SubscriptionPayment restore(
+            Long id,
+            Long subscriptionId,
+            Long orderId,
+            Long paymentId,
+            Long userId,
+            String orderNo,
+            SubscriptionPlan plan,
+            Long amount,
+            SubscriptionBillingType billingType,
+            LocalDateTime paidAt,
+            LocalDateTime createdAt
+    ) {
+        return new SubscriptionPayment(
+                id,
+                subscriptionId,
+                orderId,
+                paymentId,
+                userId,
+                orderNo,
+                plan,
+                amount,
+                billingType,
+                paidAt,
+                createdAt
+        );
+    }
+
+    public Long getId() { return id; }
+    public Long getSubscriptionId() { return subscriptionId; }
+    public Long getOrderId() { return orderId; }
+    public Long getPaymentId() { return paymentId; }
+    public Long getUserId() { return userId; }
+    public String getOrderNo() { return orderNo; }
+    public SubscriptionPlan getPlan() { return plan; }
+    public Long getAmount() { return amount; }
+    public SubscriptionBillingType getBillingType() { return billingType; }
+    public LocalDateTime getPaidAt() { return paidAt; }
+    public LocalDateTime getCreatedAt() { return createdAt; }
+}

--- a/src/main/java/com/sashimi/subscription/domain/model/SubscriptionPlan.java
+++ b/src/main/java/com/sashimi/subscription/domain/model/SubscriptionPlan.java
@@ -1,0 +1,87 @@
+package com.sashimi.subscription.domain.model;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public enum SubscriptionPlan {
+
+    MONTHLY(
+            "1개월 플랜",
+            1,
+            10_000L,
+            10_000L,
+            0,
+            List.of(
+                    "AI 채용 공고 분석",
+                    "AI 이력서 작성 및 평가",
+                    "기업 내 무제한 이용"
+            )
+    ),
+
+    ANNUAL(
+            "12개월 플랜",
+            12,
+            120_000L,
+            100_000L,
+            17,
+            List.of(
+                    "AI 채용 공고 분석",
+                    "AI 이력서 작성 및 평가",
+                    "기간 내 무제한 이용",
+                    "장기 이용 할인"
+            )
+    );
+
+    private final String planName;
+    private final int durationMonths;
+    private final Long originalPrice;
+    private final Long price;
+    private final int discountRate;
+    private final List<String> features;
+
+    SubscriptionPlan(
+            String planName,
+            int durationMonths,
+            Long originalPrice,
+            Long price,
+            int discountRate,
+            List<String> features
+    ) {
+        this.planName = planName;
+        this.durationMonths = durationMonths;
+        this.originalPrice = originalPrice;
+        this.price = price;
+        this.discountRate = discountRate;
+        this.features = List.copyOf(features);
+    }
+
+    public LocalDateTime calculateExpiration(
+            LocalDateTime startedAt
+    ) {
+        return startedAt.plusMonths(durationMonths);
+    }
+
+    public String getPlanName() {
+        return planName;
+    }
+
+    public int getDurationMonths() {
+        return durationMonths;
+    }
+
+    public Long getOriginalPrice() {
+        return originalPrice;
+    }
+
+    public Long getPrice() {
+        return price;
+    }
+
+    public int getDiscountRate() {
+        return discountRate;
+    }
+
+    public List<String> getFeatures() {
+        return features;
+    }
+}

--- a/src/main/java/com/sashimi/subscription/domain/model/SubscriptionStatus.java
+++ b/src/main/java/com/sashimi/subscription/domain/model/SubscriptionStatus.java
@@ -1,0 +1,8 @@
+package com.sashimi.subscription.domain.model;
+
+public enum SubscriptionStatus {
+    ACTIVE,
+    EXPIRED,
+    CANCELLED,
+    PAUSED
+}

--- a/src/main/java/com/sashimi/subscription/domain/repository/SubscriptionPaymentRepository.java
+++ b/src/main/java/com/sashimi/subscription/domain/repository/SubscriptionPaymentRepository.java
@@ -1,0 +1,27 @@
+package com.sashimi.subscription.domain.repository;
+
+import com.sashimi.subscription.domain.model.SubscriptionPayment;
+
+import java.util.List;
+
+public interface SubscriptionPaymentRepository {
+
+    SubscriptionPayment save(
+            SubscriptionPayment subscriptionPayment
+    );
+
+    PageResult findAllByUserId(
+            Long userId,
+            int page,
+            int size
+    );
+
+    record PageResult(
+            List<SubscriptionPayment> content,
+            long totalElements,
+            int totalPages,
+            int page,
+            int size
+    ) {
+    }
+}

--- a/src/main/java/com/sashimi/subscription/domain/repository/SubscriptionRepository.java
+++ b/src/main/java/com/sashimi/subscription/domain/repository/SubscriptionRepository.java
@@ -1,0 +1,18 @@
+package com.sashimi.subscription.domain.repository;
+
+import com.sashimi.subscription.domain.model.Subscription;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+public interface SubscriptionRepository {
+
+    Subscription save(Subscription subscription);
+
+    Optional<Subscription> findById(Long subscriptionId);
+
+    Optional<Subscription> findActiveByUserId(
+            Long userId,
+            LocalDateTime now
+    );
+}

--- a/src/main/java/com/sashimi/subscription/infrastructure/persistence/SpringDataSubscriptionPaymentRepository.java
+++ b/src/main/java/com/sashimi/subscription/infrastructure/persistence/SpringDataSubscriptionPaymentRepository.java
@@ -1,0 +1,15 @@
+package com.sashimi.subscription.infrastructure.persistence;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface SpringDataSubscriptionPaymentRepository
+        extends JpaRepository<SubscriptionPaymentJpaEntity, Long> {
+
+    Page<SubscriptionPaymentJpaEntity>
+    findAllByUserIdOrderByPaidAtDesc(
+            Long userId,
+            Pageable pageable
+    );
+}

--- a/src/main/java/com/sashimi/subscription/infrastructure/persistence/SpringDataSubscriptionRepository.java
+++ b/src/main/java/com/sashimi/subscription/infrastructure/persistence/SpringDataSubscriptionRepository.java
@@ -1,0 +1,20 @@
+package com.sashimi.subscription.infrastructure.persistence;
+
+import com.sashimi.subscription.domain.model.SubscriptionStatus;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public interface SpringDataSubscriptionRepository
+        extends JpaRepository<SubscriptionJpaEntity, Long> {
+
+    List<SubscriptionJpaEntity>
+    findByUserIdAndStatusAndExpiredAtAfterOrderByStartedAtDesc(
+            Long userId,
+            SubscriptionStatus status,
+            LocalDateTime now,
+            Pageable pageable
+    );
+}

--- a/src/main/java/com/sashimi/subscription/infrastructure/persistence/SubscriptionJpaEntity.java
+++ b/src/main/java/com/sashimi/subscription/infrastructure/persistence/SubscriptionJpaEntity.java
@@ -1,0 +1,80 @@
+package com.sashimi.subscription.infrastructure.persistence;
+
+import com.sashimi.subscription.domain.model.Subscription;
+import com.sashimi.subscription.domain.model.SubscriptionPlan;
+import com.sashimi.subscription.domain.model.SubscriptionStatus;
+import jakarta.persistence.*;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "subscriptions")
+public class SubscriptionJpaEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "subscription_id")
+    private Long id;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "type", nullable = false)
+    private SubscriptionPlan plan;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", nullable = false)
+    private SubscriptionStatus status;
+
+    @Column(name = "price", nullable = false)
+    private Long price;
+
+    @Column(name = "started_at", nullable = false)
+    private LocalDateTime startedAt;
+
+    @Column(name = "expired_at")
+    private LocalDateTime expiredAt;
+
+    @Column(name = "next_billing_at")
+    private LocalDateTime nextBillingAt;
+
+    @Column(name = "auto_renew", nullable = false)
+    private boolean autoRenew;
+
+    @Column(name = "user_id", nullable = false)
+    private Long userId;
+
+    protected SubscriptionJpaEntity() {
+    }
+
+    public static SubscriptionJpaEntity from(
+            Subscription subscription
+    ) {
+        SubscriptionJpaEntity entity =
+                new SubscriptionJpaEntity();
+
+        entity.id = subscription.getId();
+        entity.plan = subscription.getPlan();
+        entity.status = subscription.getStatus();
+        entity.price = subscription.getPrice();
+        entity.startedAt = subscription.getStartedAt();
+        entity.expiredAt = subscription.getExpiredAt();
+        entity.nextBillingAt = subscription.getNextBillingAt();
+        entity.autoRenew = subscription.isAutoRenew();
+        entity.userId = subscription.getUserId();
+
+        return entity;
+    }
+
+    public Subscription toDomain() {
+        return Subscription.restore(
+                id,
+                plan,
+                status,
+                price,
+                startedAt,
+                expiredAt,
+                nextBillingAt,
+                autoRenew,
+                userId
+        );
+    }
+}

--- a/src/main/java/com/sashimi/subscription/infrastructure/persistence/SubscriptionPaymentJpaEntity.java
+++ b/src/main/java/com/sashimi/subscription/infrastructure/persistence/SubscriptionPaymentJpaEntity.java
@@ -1,0 +1,88 @@
+package com.sashimi.subscription.infrastructure.persistence;
+
+import com.sashimi.subscription.domain.model.*;
+import jakarta.persistence.*;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "subscription_payments")
+public class SubscriptionPaymentJpaEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "subscription_payment_id")
+    private Long id;
+
+    @Column(name = "subscription_id", nullable = false)
+    private Long subscriptionId;
+
+    @Column(name = "order_id", nullable = false)
+    private Long orderId;
+
+    @Column(name = "payment_id", nullable = false)
+    private Long paymentId;
+
+    @Column(name = "user_id", nullable = false)
+    private Long userId;
+
+    @Column(name = "order_no", nullable = false)
+    private String orderNo;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "plan_code", nullable = false)
+    private SubscriptionPlan plan;
+
+    @Column(name = "amount", nullable = false)
+    private Long amount;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "billing_type", nullable = false)
+    private SubscriptionBillingType billingType;
+
+    @Column(name = "paid_at", nullable = false)
+    private LocalDateTime paidAt;
+
+    @Column(name = "created_at", nullable = false)
+    private LocalDateTime createdAt;
+
+    protected SubscriptionPaymentJpaEntity() {
+    }
+
+    public static SubscriptionPaymentJpaEntity from(
+            SubscriptionPayment payment
+    ) {
+        SubscriptionPaymentJpaEntity entity =
+                new SubscriptionPaymentJpaEntity();
+
+        entity.id = payment.getId();
+        entity.subscriptionId = payment.getSubscriptionId();
+        entity.orderId = payment.getOrderId();
+        entity.paymentId = payment.getPaymentId();
+        entity.userId = payment.getUserId();
+        entity.orderNo = payment.getOrderNo();
+        entity.plan = payment.getPlan();
+        entity.amount = payment.getAmount();
+        entity.billingType = payment.getBillingType();
+        entity.paidAt = payment.getPaidAt();
+        entity.createdAt = payment.getCreatedAt();
+
+        return entity;
+    }
+
+    public SubscriptionPayment toDomain() {
+        return SubscriptionPayment.restore(
+                id,
+                subscriptionId,
+                orderId,
+                paymentId,
+                userId,
+                orderNo,
+                plan,
+                amount,
+                billingType,
+                paidAt,
+                createdAt
+        );
+    }
+}

--- a/src/main/java/com/sashimi/subscription/infrastructure/persistence/SubscriptionPaymentRepositoryAdapter.java
+++ b/src/main/java/com/sashimi/subscription/infrastructure/persistence/SubscriptionPaymentRepositoryAdapter.java
@@ -1,0 +1,56 @@
+package com.sashimi.subscription.infrastructure.persistence;
+
+import com.sashimi.subscription.domain.model.SubscriptionPayment;
+import com.sashimi.subscription.domain.repository.SubscriptionPaymentRepository;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public class SubscriptionPaymentRepositoryAdapter
+        implements SubscriptionPaymentRepository {
+
+    private final SpringDataSubscriptionPaymentRepository repository;
+
+    public SubscriptionPaymentRepositoryAdapter(
+            SpringDataSubscriptionPaymentRepository repository
+    ) {
+        this.repository = repository;
+    }
+
+    @Override
+    public SubscriptionPayment save(
+            SubscriptionPayment subscriptionPayment
+    ) {
+        SubscriptionPaymentJpaEntity entity =
+                SubscriptionPaymentJpaEntity.from(
+                        subscriptionPayment
+                );
+
+        return repository.save(entity).toDomain();
+    }
+
+    @Override
+    public PageResult findAllByUserId(
+            Long userId,
+            int page,
+            int size
+    ) {
+        Page<SubscriptionPaymentJpaEntity> result =
+                repository.findAllByUserIdOrderByPaidAtDesc(
+                        userId,
+                        PageRequest.of(page, size)
+                );
+
+        return new PageResult(
+                result.getContent()
+                        .stream()
+                        .map(SubscriptionPaymentJpaEntity::toDomain)
+                        .toList(),
+                result.getTotalElements(),
+                result.getTotalPages(),
+                result.getNumber(),
+                result.getSize()
+        );
+    }
+}

--- a/src/main/java/com/sashimi/subscription/infrastructure/persistence/SubscriptionRepositoryAdapter.java
+++ b/src/main/java/com/sashimi/subscription/infrastructure/persistence/SubscriptionRepositoryAdapter.java
@@ -1,0 +1,53 @@
+package com.sashimi.subscription.infrastructure.persistence;
+
+import com.sashimi.subscription.domain.model.Subscription;
+import com.sashimi.subscription.domain.model.SubscriptionStatus;
+import com.sashimi.subscription.domain.repository.SubscriptionRepository;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+@Repository
+public class SubscriptionRepositoryAdapter
+        implements SubscriptionRepository {
+
+    private final SpringDataSubscriptionRepository repository;
+
+    public SubscriptionRepositoryAdapter(
+            SpringDataSubscriptionRepository repository
+    ) {
+        this.repository = repository;
+    }
+
+    @Override
+    public Subscription save(Subscription subscription) {
+        return repository.save(
+                SubscriptionJpaEntity.from(subscription)
+        ).toDomain();
+    }
+
+    @Override
+    public Optional<Subscription> findById(Long subscriptionId) {
+        return repository.findById(subscriptionId)
+                .map(SubscriptionJpaEntity::toDomain);
+    }
+
+    @Override
+    public Optional<Subscription> findActiveByUserId(
+            Long userId,
+            LocalDateTime now
+    ) {
+        return repository
+                .findByUserIdAndStatusAndExpiredAtAfterOrderByStartedAtDesc(
+                        userId,
+                        SubscriptionStatus.ACTIVE,
+                        now,
+                        PageRequest.of(0, 1)
+                )
+                .stream()
+                .findFirst()
+                .map(SubscriptionJpaEntity::toDomain);
+    }
+}

--- a/src/main/java/com/sashimi/subscription/presentation/api/SubscriptionController.java
+++ b/src/main/java/com/sashimi/subscription/presentation/api/SubscriptionController.java
@@ -1,0 +1,178 @@
+package com.sashimi.subscription.presentation.api;
+
+import com.sashimi.global.exception.ErrorResponse;
+import com.sashimi.security.principal.CustomUserPrincipal;
+import com.sashimi.subscription.application.usecase.SubscriptionQueryUseCase;
+import com.sashimi.subscription.presentation.api.response.MySubscriptionResponse;
+import com.sashimi.subscription.presentation.api.response.SubscriptionPaymentHistoryResponse;
+import com.sashimi.subscription.presentation.api.response.SubscriptionPlansResponse;
+import com.sashimi.subscription.presentation.api.response.SubscriptionPreviewResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@Validated
+@Tag(
+        name = "Subscription",
+        description = "AI 구독권 API"
+)
+@SecurityRequirement(name = "bearerAuth")
+@RestController
+@RequestMapping("/subscriptions")
+public class SubscriptionController {
+
+    private final SubscriptionQueryUseCase subscriptionQueryUseCase;
+
+    public SubscriptionController(
+            SubscriptionQueryUseCase subscriptionQueryUseCase
+    ) {
+        this.subscriptionQueryUseCase =
+                subscriptionQueryUseCase;
+    }
+
+    @Operation(
+            summary = "AI 구독권 플랜 목록 조회",
+            description = "구매 가능한 월간 및 연간 플랜을 조회합니다."
+    )
+    @ApiResponses({
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "플랜 목록 조회 성공",
+                    content = @Content(
+                            schema = @Schema(
+                                    implementation =
+                                            SubscriptionPlansResponse.class
+                            )
+                    )
+            )
+    })
+    @GetMapping("/plans")
+    public ResponseEntity<SubscriptionPlansResponse> getPlans() {
+        return ResponseEntity.ok(
+                SubscriptionPlansResponse.from(
+                        subscriptionQueryUseCase.getPlans()
+                )
+        );
+    }
+
+    @Operation(
+            summary = "AI 구독권 결제 전 정보 조회",
+            description = """
+                    선택한 구독 플랜과 현재 크레딧 잔액,
+                    결제 후 예상 잔액 및 구매 가능 여부를 조회합니다.
+                    """
+    )
+    @ApiResponses({
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "결제 전 정보 조회 성공",
+                    content = @Content(
+                            schema = @Schema(
+                                    implementation =
+                                            SubscriptionPreviewResponse.class
+                            )
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "400",
+                    description = "유효하지 않은 플랜",
+                    content = @Content(
+                            schema = @Schema(
+                                    implementation = ErrorResponse.class
+                            )
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "401",
+                    description = "인증 실패",
+                    content = @Content(
+                            schema = @Schema(
+                                    implementation = ErrorResponse.class
+                            )
+                    )
+            )
+    })
+    @GetMapping("/plans/{planCode}/preview")
+    public ResponseEntity<SubscriptionPreviewResponse>
+    getPreview(
+            @AuthenticationPrincipal
+            CustomUserPrincipal principal,
+
+            @PathVariable
+            String planCode
+    ) {
+        return ResponseEntity.ok(
+                SubscriptionPreviewResponse.from(
+                        subscriptionQueryUseCase.getPreview(
+                                principal.getId(),
+                                planCode
+                        )
+                )
+        );
+    }
+
+    @Operation(
+            summary = "내 현재 AI 구독 상태 조회",
+            description = "현재 활성화된 AI 구독 상태를 조회합니다."
+    )
+    @GetMapping("/me")
+    public ResponseEntity<MySubscriptionResponse>
+    getMySubscription(
+            @AuthenticationPrincipal
+            CustomUserPrincipal principal
+    ) {
+        return ResponseEntity.ok(
+                MySubscriptionResponse.from(
+                        subscriptionQueryUseCase
+                                .getMySubscription(
+                                        principal.getId()
+                                )
+                )
+        );
+    }
+
+    @Operation(
+            summary = "내 AI 구독 결제 내역 조회",
+            description = "최초 결제 및 갱신 결제 내역을 조회합니다."
+    )
+    @GetMapping("/payments")
+    public ResponseEntity<SubscriptionPaymentHistoryResponse>
+    getPaymentHistory(
+            @AuthenticationPrincipal
+            CustomUserPrincipal principal,
+
+            @RequestParam(defaultValue = "0")
+            @Min(value = 0, message = "페이지 번호는 0 이상이어야 합니다.")
+            int page,
+
+            @RequestParam(defaultValue = "10")
+            @Min(value = 1, message = "페이지 크기는 1 이상이어야 합니다.")
+            @Max(value = 100, message = "페이지 크기는 100 이하여야 합니다.")
+            int size
+    ) {
+        return ResponseEntity.ok(
+                SubscriptionPaymentHistoryResponse.from(
+                        subscriptionQueryUseCase
+                                .getPaymentHistory(
+                                        principal.getId(),
+                                        page,
+                                        size
+                                )
+                )
+        );
+    }
+}

--- a/src/main/java/com/sashimi/subscription/presentation/api/response/MySubscriptionResponse.java
+++ b/src/main/java/com/sashimi/subscription/presentation/api/response/MySubscriptionResponse.java
@@ -1,0 +1,56 @@
+package com.sashimi.subscription.presentation.api.response;
+
+import com.sashimi.subscription.application.usecase.SubscriptionQueryUseCase;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.time.LocalDateTime;
+
+public record MySubscriptionResponse(
+
+        @Schema(description = "현재 구독 여부")
+        boolean subscribed,
+
+        @Schema(description = "구독 ID", nullable = true)
+        Long subscriptionId,
+
+        @Schema(description = "플랜 코드", nullable = true)
+        String planCode,
+
+        @Schema(description = "플랜명", nullable = true)
+        String planName,
+
+        @Schema(description = "구독 상태", nullable = true)
+        String status,
+
+        @Schema(description = "구독 시작일", nullable = true)
+        LocalDateTime startedAt,
+
+        @Schema(description = "현재 이용 만료일", nullable = true)
+        LocalDateTime expiresAt,
+
+        @Schema(description = "다음 자동 결제 예정일", nullable = true)
+        LocalDateTime nextBillingAt,
+
+        @Schema(description = "자동 갱신 여부")
+        boolean autoRenew,
+
+        @Schema(description = "해지 신청 가능 여부")
+        boolean cancellable
+) {
+    public static MySubscriptionResponse from(
+            SubscriptionQueryUseCase.MySubscriptionResult result
+    ) {
+        return new MySubscriptionResponse(
+                result.subscribed(),
+                result.subscriptionId(),
+                result.planCode(),
+                result.planName(),
+                result.status(),
+                result.startedAt(),
+                result.expiresAt(),
+                result.nextBillingAt(),
+                result.autoRenew(),
+                result.cancellable()
+        );
+    }
+}

--- a/src/main/java/com/sashimi/subscription/presentation/api/response/SubscriptionPaymentHistoryItemResponse.java
+++ b/src/main/java/com/sashimi/subscription/presentation/api/response/SubscriptionPaymentHistoryItemResponse.java
@@ -1,0 +1,52 @@
+package com.sashimi.subscription.presentation.api.response;
+
+import com.sashimi.subscription.application.usecase.SubscriptionQueryUseCase;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.time.LocalDateTime;
+
+public record SubscriptionPaymentHistoryItemResponse(
+
+        @Schema(description = "구독 결제 내역 ID")
+        Long subscriptionPaymentId,
+
+        @Schema(description = "구독 ID")
+        Long subscriptionId,
+
+        @Schema(description = "주문 ID")
+        Long orderId,
+
+        @Schema(description = "주문번호")
+        String orderNo,
+
+        @Schema(description = "플랜 코드")
+        String planCode,
+
+        @Schema(description = "플랜명")
+        String planName,
+
+        @Schema(description = "결제 크레딧")
+        Long amount,
+
+        @Schema(description = "결제 유형")
+        String billingType,
+
+        @Schema(description = "결제 완료일")
+        LocalDateTime paidAt
+) {
+    public static SubscriptionPaymentHistoryItemResponse from(
+            SubscriptionQueryUseCase.PaymentHistoryItem result
+    ) {
+        return new SubscriptionPaymentHistoryItemResponse(
+                result.subscriptionPaymentId(),
+                result.subscriptionId(),
+                result.orderId(),
+                result.orderNo(),
+                result.planCode(),
+                result.planName(),
+                result.amount(),
+                result.billingType(),
+                result.paidAt()
+        );
+    }
+}

--- a/src/main/java/com/sashimi/subscription/presentation/api/response/SubscriptionPaymentHistoryResponse.java
+++ b/src/main/java/com/sashimi/subscription/presentation/api/response/SubscriptionPaymentHistoryResponse.java
@@ -1,0 +1,42 @@
+package com.sashimi.subscription.presentation.api.response;
+
+import com.sashimi.subscription.application.usecase.SubscriptionQueryUseCase;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.util.List;
+
+public record SubscriptionPaymentHistoryResponse(
+
+        @Schema(description = "구독 결제 내역")
+        List<SubscriptionPaymentHistoryItemResponse> items,
+
+        @Schema(description = "전체 항목 수")
+        long totalElements,
+
+        @Schema(description = "전체 페이지 수")
+        int totalPages,
+
+        @Schema(description = "현재 페이지 번호")
+        int page,
+
+        @Schema(description = "페이지 크기")
+        int size
+) {
+    public static SubscriptionPaymentHistoryResponse from(
+            SubscriptionQueryUseCase.PaymentHistoryResult result
+    ) {
+        return new SubscriptionPaymentHistoryResponse(
+                result.items()
+                        .stream()
+                        .map(
+                                SubscriptionPaymentHistoryItemResponse
+                                        ::from
+                        )
+                        .toList(),
+                result.totalElements(),
+                result.totalPages(),
+                result.page(),
+                result.size()
+        );
+    }
+}

--- a/src/main/java/com/sashimi/subscription/presentation/api/response/SubscriptionPlanResponse.java
+++ b/src/main/java/com/sashimi/subscription/presentation/api/response/SubscriptionPlanResponse.java
@@ -1,0 +1,44 @@
+package com.sashimi.subscription.presentation.api.response;
+
+import com.sashimi.subscription.application.usecase.SubscriptionQueryUseCase;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.util.List;
+
+public record SubscriptionPlanResponse(
+
+        @Schema(description = "플랜 코드", example = "MONTHLY")
+        String planCode,
+
+        @Schema(description = "플랜명", example = "1개월 플랜")
+        String planName,
+
+        @Schema(description = "구독 기간(개월)", example = "1")
+        int durationMonths,
+
+        @Schema(description = "할인 전 가격", example = "10000")
+        Long originalPrice,
+
+        @Schema(description = "실제 결제 가격", example = "10000")
+        Long price,
+
+        @Schema(description = "할인율", example = "0")
+        int discountRate,
+
+        @Schema(description = "플랜 제공 기능")
+        List<String> features
+) {
+    public static SubscriptionPlanResponse from(
+            SubscriptionQueryUseCase.PlanResult result
+    ) {
+        return new SubscriptionPlanResponse(
+                result.planCode(),
+                result.planName(),
+                result.durationMonths(),
+                result.originalPrice(),
+                result.price(),
+                result.discountRate(),
+                result.features()
+        );
+    }
+}

--- a/src/main/java/com/sashimi/subscription/presentation/api/response/SubscriptionPlansResponse.java
+++ b/src/main/java/com/sashimi/subscription/presentation/api/response/SubscriptionPlansResponse.java
@@ -1,0 +1,22 @@
+package com.sashimi.subscription.presentation.api.response;
+
+import com.sashimi.subscription.application.usecase.SubscriptionQueryUseCase;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.util.List;
+
+public record SubscriptionPlansResponse(
+
+        @Schema(description = "AI 구독권 플랜 목록")
+        List<SubscriptionPlanResponse> plans
+) {
+    public static SubscriptionPlansResponse from(
+            List<SubscriptionQueryUseCase.PlanResult> results
+    ) {
+        return new SubscriptionPlansResponse(
+                results.stream()
+                        .map(SubscriptionPlanResponse::from)
+                        .toList()
+        );
+    }
+}

--- a/src/main/java/com/sashimi/subscription/presentation/api/response/SubscriptionPreviewResponse.java
+++ b/src/main/java/com/sashimi/subscription/presentation/api/response/SubscriptionPreviewResponse.java
@@ -1,0 +1,67 @@
+package com.sashimi.subscription.presentation.api.response;
+
+import com.sashimi.subscription.application.usecase.SubscriptionQueryUseCase;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.util.List;
+
+public record SubscriptionPreviewResponse(
+
+        @Schema(description = "플랜 코드", example = "MONTHLY")
+        String planCode,
+
+        @Schema(description = "플랜명", example = "1개월 플랜")
+        String planName,
+
+        @Schema(description = "구독 기간(개월)", example = "1")
+        int durationMonths,
+
+        @Schema(description = "할인 전 가격", example = "10000")
+        Long originalPrice,
+
+        @Schema(description = "실제 결제 가격", example = "10000")
+        Long price,
+
+        @Schema(description = "할인율", example = "0")
+        int discountRate,
+
+        @Schema(description = "플랜 제공 기능")
+        List<String> features,
+
+        @Schema(description = "현재 보유 크레딧", example = "30000")
+        Long creditBalance,
+
+        @Schema(description = "결제 후 예상 잔액", example = "20000")
+        Long balanceAfterPayment,
+
+        @Schema(description = "부족한 크레딧", example = "0")
+        Long insufficientAmount,
+
+        @Schema(description = "현재 활성 구독 보유 여부")
+        boolean alreadySubscribed,
+
+        @Schema(description = "구매 가능 여부")
+        boolean purchasable
+) {
+    public static SubscriptionPreviewResponse from(
+            SubscriptionQueryUseCase.PreviewResult result
+    ) {
+        SubscriptionQueryUseCase.PlanResult plan =
+                result.plan();
+
+        return new SubscriptionPreviewResponse(
+                plan.planCode(),
+                plan.planName(),
+                plan.durationMonths(),
+                plan.originalPrice(),
+                plan.price(),
+                plan.discountRate(),
+                plan.features(),
+                result.creditBalance(),
+                result.balanceAfterPayment(),
+                result.insufficientAmount(),
+                result.alreadySubscribed(),
+                result.purchasable()
+        );
+    }
+}

--- a/src/main/resources/db/migration/V2.15__create_ai_subscription_payment.sql
+++ b/src/main/resources/db/migration/V2.15__create_ai_subscription_payment.sql
@@ -1,0 +1,78 @@
+-- 기존 구독 타입을 신규 플랜으로 변환하기 위한 임시 확장
+ALTER TABLE subscriptions
+    MODIFY COLUMN type ENUM(
+    'BASIC',
+    'PREMIUM',
+    'PRO',
+    'MONTHLY',
+    'ANNUAL'
+    ) NOT NULL;
+
+UPDATE subscriptions
+SET type = 'MONTHLY'
+WHERE type IN ('BASIC', 'PREMIUM');
+
+UPDATE subscriptions
+SET type = 'ANNUAL'
+WHERE type = 'PRO';
+
+ALTER TABLE subscriptions
+    MODIFY COLUMN type ENUM('MONTHLY', 'ANNUAL') NOT NULL;
+
+ALTER TABLE subscriptions
+    ADD INDEX idx_subscriptions_user_status (
+        user_id,
+        status
+    ),
+    ADD INDEX idx_subscriptions_next_billing (
+        status,
+        auto_renew,
+        next_billing_at
+    );
+
+CREATE TABLE subscription_payments (
+                                       subscription_payment_id BIGINT AUTO_INCREMENT PRIMARY KEY,
+
+                                       subscription_id BIGINT NOT NULL,
+                                       order_id BIGINT NOT NULL,
+                                       payment_id BIGINT NOT NULL,
+                                       user_id BIGINT NOT NULL,
+
+                                       order_no VARCHAR(100) NOT NULL,
+                                       plan_code ENUM('MONTHLY', 'ANNUAL') NOT NULL,
+                                       amount BIGINT NOT NULL,
+                                       billing_type ENUM('INITIAL', 'RENEWAL') NOT NULL,
+                                       paid_at DATETIME NOT NULL,
+                                       created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+                                       CONSTRAINT fk_subscription_payments_subscription
+                                           FOREIGN KEY (subscription_id)
+                                               REFERENCES subscriptions(subscription_id),
+
+                                       CONSTRAINT fk_subscription_payments_order
+                                           FOREIGN KEY (order_id)
+                                               REFERENCES orders(order_id),
+
+                                       CONSTRAINT fk_subscription_payments_payment
+                                           FOREIGN KEY (payment_id)
+                                               REFERENCES payments(payment_id),
+
+                                       CONSTRAINT fk_subscription_payments_user
+                                           FOREIGN KEY (user_id)
+                                               REFERENCES users(user_id),
+
+                                       CONSTRAINT uq_subscription_payments_order
+                                           UNIQUE (order_id),
+
+                                       CONSTRAINT uq_subscription_payments_payment
+                                           UNIQUE (payment_id),
+
+                                       INDEX idx_subscription_payments_user_paid_at (
+        user_id,
+        paid_at
+    ),
+
+                                       INDEX idx_subscription_payments_subscription (
+        subscription_id
+    )
+);

--- a/src/test/java/com/sashimi/payment/application/service/PaymentCommandServiceTest.java
+++ b/src/test/java/com/sashimi/payment/application/service/PaymentCommandServiceTest.java
@@ -4,6 +4,7 @@ import com.sashimi.cart.application.port.CourseInfo;
 import com.sashimi.cart.domain.model.CartItem;
 import com.sashimi.cart.domain.repository.CartItemRepository;
 import com.sashimi.credit.application.command.UseCreditCommand;
+import com.sashimi.credit.application.result.CreditBalanceResult;
 import com.sashimi.credit.application.usecase.CreditCommandUseCase;
 import com.sashimi.enrollment.application.port.EnrollmentPort;
 import com.sashimi.global.exception.BusinessException;
@@ -11,6 +12,7 @@ import com.sashimi.global.exception.ErrorCode;
 import com.sashimi.order.application.policy.CoursePurchasePolicy;
 import com.sashimi.order.domain.model.Order;
 import com.sashimi.order.domain.model.OrderItem;
+import com.sashimi.order.domain.model.OrderItemType;
 import com.sashimi.order.domain.model.OrderStatus;
 import com.sashimi.order.domain.repository.OrderItemRepository;
 import com.sashimi.order.domain.repository.OrderRepository;
@@ -19,27 +21,41 @@ import com.sashimi.payment.application.command.PaymentPurchaseType;
 import com.sashimi.payment.domain.model.Payment;
 import com.sashimi.payment.domain.model.PaymentStatus;
 import com.sashimi.payment.domain.repository.PaymentRepository;
+import com.sashimi.subscription.domain.model.Subscription;
+import com.sashimi.subscription.domain.model.SubscriptionPayment;
+import com.sashimi.subscription.domain.model.SubscriptionPlan;
+import com.sashimi.subscription.domain.model.SubscriptionStatus;
+import com.sashimi.subscription.domain.repository.SubscriptionPaymentRepository;
+import com.sashimi.subscription.domain.repository.SubscriptionRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.catchThrowableOfType;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.*;
 
 class PaymentCommandServiceTest {
 
     private static final Long USER_ID = 1L;
+
     private static final Long COURSE_ID = 100L;
     private static final Long COURSE_PRICE = 30_000L;
+
     private static final Long ORDER_ID = 1L;
     private static final Long ORDER_ITEM_ID = 11L;
     private static final Long PAYMENT_ID = 20L;
+
+    private static final Long SUBSCRIPTION_ID = 30L;
+    private static final Long SUBSCRIPTION_ORDER_ITEM_ID = 31L;
+    private static final Long MONTHLY_PRICE = 10_000L;
 
     private CartItemRepository cartItemRepository;
     private CoursePurchasePolicy coursePurchasePolicy;
@@ -48,18 +64,39 @@ class PaymentCommandServiceTest {
     private OrderItemRepository orderItemRepository;
     private PaymentRepository paymentRepository;
     private CreditCommandUseCase creditCommandUseCase;
+    private SubscriptionRepository subscriptionRepository;
+    private SubscriptionPaymentRepository subscriptionPaymentRepository;
 
     private PaymentCommandService paymentCommandService;
 
     @BeforeEach
     void setUp() {
-        cartItemRepository = mock(CartItemRepository.class);
-        coursePurchasePolicy = mock(CoursePurchasePolicy.class);
-        enrollmentPort = mock(EnrollmentPort.class);
-        orderRepository = mock(OrderRepository.class);
-        orderItemRepository = mock(OrderItemRepository.class);
-        paymentRepository = mock(PaymentRepository.class);
-        creditCommandUseCase = mock(CreditCommandUseCase.class);
+        cartItemRepository =
+                mock(CartItemRepository.class);
+
+        coursePurchasePolicy =
+                mock(CoursePurchasePolicy.class);
+
+        enrollmentPort =
+                mock(EnrollmentPort.class);
+
+        orderRepository =
+                mock(OrderRepository.class);
+
+        orderItemRepository =
+                mock(OrderItemRepository.class);
+
+        paymentRepository =
+                mock(PaymentRepository.class);
+
+        creditCommandUseCase =
+                mock(CreditCommandUseCase.class);
+
+        subscriptionRepository =
+                mock(SubscriptionRepository.class);
+
+        subscriptionPaymentRepository =
+                mock(SubscriptionPaymentRepository.class);
 
         paymentCommandService = new PaymentCommandService(
                 cartItemRepository,
@@ -68,213 +105,700 @@ class PaymentCommandServiceTest {
                 orderRepository,
                 orderItemRepository,
                 paymentRepository,
-                creditCommandUseCase
+                creditCommandUseCase,
+                subscriptionRepository,
+                subscriptionPaymentRepository
         );
     }
 
     @Test
-    void 장바구니에서_선택한_강의를_결제하면_크레딧을_차감하고_수강_등록한_뒤_선택_항목을_삭제한다() {
+    void checkout_cart_pays_selected_courses() {
         CartItem cartItem = createCartItem();
         CourseInfo courseInfo = createCourseInfo();
-        Order savedOrder = createSavedOrder();
-        OrderItem savedOrderItem = createSavedOrderItem();
-        Payment savedPayment = createSavedPayment();
+        Order savedOrder = createSavedCourseOrder();
+        OrderItem savedOrderItem = createSavedCourseOrderItem();
+        Payment savedPayment = createSavedCoursePayment();
 
         when(cartItemRepository.findAllSelectedByUserId(USER_ID))
                 .thenReturn(List.of(cartItem));
-        when(coursePurchasePolicy.validatePurchasable(USER_ID, COURSE_ID))
-                .thenReturn(courseInfo);
+
+        when(coursePurchasePolicy.validatePurchasable(
+                USER_ID,
+                COURSE_ID
+        )).thenReturn(courseInfo);
+
         when(orderRepository.save(any(Order.class)))
                 .thenReturn(savedOrder);
+
         when(orderItemRepository.save(any(OrderItem.class)))
                 .thenReturn(savedOrderItem);
+
         when(paymentRepository.save(any(Payment.class)))
                 .thenReturn(savedPayment);
+
+        when(creditCommandUseCase.useCredit(
+                any(UseCreditCommand.class)
+        )).thenReturn(
+                new CreditBalanceResult(70_000L)
+        );
 
         var result = paymentCommandService.checkout(
                 new PaymentCheckoutCommand(
                         USER_ID,
                         PaymentPurchaseType.CART,
                         null,
+                        null,
                         true
                 )
         );
 
-        assertThat(result.orderId()).isEqualTo(ORDER_ID);
-        assertThat(result.orderNo()).isEqualTo("ORD-TEST");
-        assertThat(result.paymentId()).isEqualTo(PAYMENT_ID);
-        assertThat(result.amount()).isEqualTo(COURSE_PRICE);
-        assertThat(result.status()).isEqualTo("PAID");
-        assertThat(result.courses()).hasSize(1);
+        assertThat(result.orderId())
+                .isEqualTo(ORDER_ID);
+
+        assertThat(result.orderNo())
+                .isEqualTo("ORD-TEST");
+
+        assertThat(result.paymentId())
+                .isEqualTo(PAYMENT_ID);
+
+        assertThat(result.purchaseType())
+                .isEqualTo(PaymentPurchaseType.CART);
+
+        assertThat(result.amount())
+                .isEqualTo(COURSE_PRICE);
+
+        assertThat(result.status())
+                .isEqualTo("PAID");
+
+        assertThat(result.creditBalance())
+                .isEqualTo(70_000L);
+
+        assertThat(result.courses())
+                .hasSize(1);
+
+        assertThat(result.subscription())
+                .isNull();
+
         assertThat(result.courses().get(0).courseId())
                 .isEqualTo(COURSE_ID);
+
         assertThat(result.courses().get(0).title())
                 .isEqualTo("Spring Boot Basic");
+
         assertThat(result.courses().get(0).price())
                 .isEqualTo(COURSE_PRICE);
 
         ArgumentCaptor<UseCreditCommand> creditCaptor =
-                ArgumentCaptor.forClass(UseCreditCommand.class);
+                ArgumentCaptor.forClass(
+                        UseCreditCommand.class
+                );
 
-        verify(creditCommandUseCase).useCredit(creditCaptor.capture());
-        assertThat(creditCaptor.getValue().userId()).isEqualTo(USER_ID);
-        assertThat(creditCaptor.getValue().amount()).isEqualTo(COURSE_PRICE);
+        verify(creditCommandUseCase)
+                .useCredit(creditCaptor.capture());
 
-        verify(coursePurchasePolicy)
-                .validatePurchasable(USER_ID, COURSE_ID);
+        assertThat(creditCaptor.getValue().userId())
+                .isEqualTo(USER_ID);
+
+        assertThat(creditCaptor.getValue().amount())
+                .isEqualTo(COURSE_PRICE);
+
         verify(enrollmentPort)
-                .enrollPaidCourse(USER_ID, COURSE_ID, ORDER_ITEM_ID);
+                .enrollPaidCourse(
+                        USER_ID,
+                        COURSE_ID,
+                        ORDER_ITEM_ID
+                );
+
         verify(cartItemRepository)
                 .deleteAllSelectedByUserId(USER_ID);
+
         verify(cartItemRepository, never())
-                .deleteByUserIdAndCourseId(anyLong(), anyLong());
+                .deleteByUserIdAndCourseId(
+                        anyLong(),
+                        anyLong()
+                );
+
+        verifyNoInteractions(subscriptionRepository);
+        verifyNoInteractions(subscriptionPaymentRepository);
     }
 
     @Test
-    void 단일_강의를_결제하면_크레딧을_차감하고_수강_등록한_뒤_같은_강의를_장바구니에서_삭제한다() {
+    void checkout_course_pays_single_course() {
         CourseInfo courseInfo = createCourseInfo();
-        Order savedOrder = createSavedOrder();
-        OrderItem savedOrderItem = createSavedOrderItem();
-        Payment savedPayment = createSavedPayment();
+        Order savedOrder = createSavedCourseOrder();
+        OrderItem savedOrderItem = createSavedCourseOrderItem();
+        Payment savedPayment = createSavedCoursePayment();
 
-        when(coursePurchasePolicy.validatePurchasable(USER_ID, COURSE_ID))
-                .thenReturn(courseInfo);
+        when(coursePurchasePolicy.validatePurchasable(
+                USER_ID,
+                COURSE_ID
+        )).thenReturn(courseInfo);
+
         when(orderRepository.save(any(Order.class)))
                 .thenReturn(savedOrder);
+
         when(orderItemRepository.save(any(OrderItem.class)))
                 .thenReturn(savedOrderItem);
+
         when(paymentRepository.save(any(Payment.class)))
                 .thenReturn(savedPayment);
+
+        when(creditCommandUseCase.useCredit(
+                any(UseCreditCommand.class)
+        )).thenReturn(
+                new CreditBalanceResult(70_000L)
+        );
 
         var result = paymentCommandService.checkout(
                 new PaymentCheckoutCommand(
                         USER_ID,
                         PaymentPurchaseType.COURSE,
                         COURSE_ID,
+                        null,
                         true
                 )
         );
 
-        assertThat(result.orderId()).isEqualTo(ORDER_ID);
-        assertThat(result.orderNo()).isEqualTo("ORD-TEST");
-        assertThat(result.paymentId()).isEqualTo(PAYMENT_ID);
-        assertThat(result.amount()).isEqualTo(COURSE_PRICE);
-        assertThat(result.status()).isEqualTo("PAID");
-        assertThat(result.courses()).hasSize(1);
-        assertThat(result.courses().get(0).courseId())
-                .isEqualTo(COURSE_ID);
+        assertThat(result.orderId())
+                .isEqualTo(ORDER_ID);
 
-        ArgumentCaptor<UseCreditCommand> creditCaptor =
-                ArgumentCaptor.forClass(UseCreditCommand.class);
+        assertThat(result.paymentId())
+                .isEqualTo(PAYMENT_ID);
 
-        verify(creditCommandUseCase).useCredit(creditCaptor.capture());
-        assertThat(creditCaptor.getValue().userId()).isEqualTo(USER_ID);
-        assertThat(creditCaptor.getValue().amount()).isEqualTo(COURSE_PRICE);
+        assertThat(result.purchaseType())
+                .isEqualTo(PaymentPurchaseType.COURSE);
 
-        verify(coursePurchasePolicy)
-                .validatePurchasable(USER_ID, COURSE_ID);
+        assertThat(result.amount())
+                .isEqualTo(COURSE_PRICE);
+
+        assertThat(result.creditBalance())
+                .isEqualTo(70_000L);
+
+        assertThat(result.courses())
+                .hasSize(1);
+
+        assertThat(result.subscription())
+                .isNull();
+
         verify(enrollmentPort)
-                .enrollPaidCourse(USER_ID, COURSE_ID, ORDER_ITEM_ID);
+                .enrollPaidCourse(
+                        USER_ID,
+                        COURSE_ID,
+                        ORDER_ITEM_ID
+                );
+
         verify(cartItemRepository)
-                .deleteByUserIdAndCourseId(USER_ID, COURSE_ID);
+                .deleteByUserIdAndCourseId(
+                        USER_ID,
+                        COURSE_ID
+                );
+
         verify(cartItemRepository, never())
                 .deleteAllSelectedByUserId(anyLong());
+
+        verifyNoInteractions(subscriptionRepository);
+        verifyNoInteractions(subscriptionPaymentRepository);
     }
 
     @Test
-    void 선택한_장바구니_항목이_없으면_결제를_진행하지_않는다() {
-        when(cartItemRepository.findAllSelectedByUserId(USER_ID))
-                .thenReturn(List.of());
+    void checkout_subscription_creates_subscription_and_payment_history() {
+        Order savedOrder = createSavedSubscriptionOrder();
+        Subscription savedSubscription =
+                createSavedSubscription();
 
-        BusinessException exception = catchThrowableOfType(
-                () -> paymentCommandService.checkout(
-                        new PaymentCheckoutCommand(
-                                USER_ID,
-                                PaymentPurchaseType.CART,
-                                null,
-                                true
-                        )
-                ),
-                BusinessException.class
+        OrderItem savedOrderItem =
+                createSavedSubscriptionOrderItem();
+
+        Payment savedPayment =
+                createSavedSubscriptionPayment();
+
+        when(subscriptionRepository.findActiveByUserId(
+                eq(USER_ID),
+                any(LocalDateTime.class)
+        )).thenReturn(Optional.empty());
+
+        when(orderRepository.save(any(Order.class)))
+                .thenReturn(savedOrder);
+
+        when(subscriptionRepository.save(
+                any(Subscription.class)
+        )).thenReturn(savedSubscription);
+
+        when(orderItemRepository.save(
+                any(OrderItem.class)
+        )).thenReturn(savedOrderItem);
+
+        when(paymentRepository.save(any(Payment.class)))
+                .thenReturn(savedPayment);
+
+        when(creditCommandUseCase.useCredit(
+                any(UseCreditCommand.class)
+        )).thenReturn(
+                new CreditBalanceResult(90_000L)
         );
+
+        when(subscriptionPaymentRepository.save(
+                any(SubscriptionPayment.class)
+        )).thenAnswer(invocation ->
+                invocation.getArgument(0)
+        );
+
+        var result = paymentCommandService.checkout(
+                new PaymentCheckoutCommand(
+                        USER_ID,
+                        PaymentPurchaseType.AI_SUBSCRIPTION,
+                        null,
+                        SubscriptionPlan.MONTHLY,
+                        true
+                )
+        );
+
+        assertThat(result.orderId())
+                .isEqualTo(ORDER_ID);
+
+        assertThat(result.paymentId())
+                .isEqualTo(PAYMENT_ID);
+
+        assertThat(result.purchaseType())
+                .isEqualTo(
+                        PaymentPurchaseType.AI_SUBSCRIPTION
+                );
+
+        assertThat(result.amount())
+                .isEqualTo(MONTHLY_PRICE);
+
+        assertThat(result.status())
+                .isEqualTo("PAID");
+
+        assertThat(result.creditBalance())
+                .isEqualTo(90_000L);
+
+        assertThat(result.courses())
+                .isEmpty();
+
+        assertThat(result.subscription())
+                .isNotNull();
+
+        assertThat(result.subscription().subscriptionId())
+                .isEqualTo(SUBSCRIPTION_ID);
+
+        assertThat(result.subscription().planCode())
+                .isEqualTo("MONTHLY");
+
+        assertThat(result.subscription().planName())
+                .isEqualTo("1개월 플랜");
+
+        assertThat(result.subscription().status())
+                .isEqualTo("ACTIVE");
+
+        ArgumentCaptor<OrderItem> orderItemCaptor =
+                ArgumentCaptor.forClass(OrderItem.class);
+
+        verify(orderItemRepository)
+                .save(orderItemCaptor.capture());
+
+        OrderItem capturedOrderItem =
+                orderItemCaptor.getValue();
+
+        assertThat(capturedOrderItem.getItemType())
+                .isEqualTo(
+                        OrderItemType.AI_SUBSCRIPTION
+                );
+
+        assertThat(capturedOrderItem.getItemId())
+                .isEqualTo(SUBSCRIPTION_ID);
+
+        assertThat(capturedOrderItem.getCourseId())
+                .isNull();
+
+        assertThat(capturedOrderItem.getCourseTitle())
+                .isEqualTo("1개월 플랜");
+
+        ArgumentCaptor<UseCreditCommand> creditCaptor =
+                ArgumentCaptor.forClass(
+                        UseCreditCommand.class
+                );
+
+        verify(creditCommandUseCase)
+                .useCredit(creditCaptor.capture());
+
+        assertThat(creditCaptor.getValue().amount())
+                .isEqualTo(MONTHLY_PRICE);
+
+        ArgumentCaptor<SubscriptionPayment>
+                subscriptionPaymentCaptor =
+                ArgumentCaptor.forClass(
+                        SubscriptionPayment.class
+                );
+
+        verify(subscriptionPaymentRepository)
+                .save(
+                        subscriptionPaymentCaptor.capture()
+                );
+
+        SubscriptionPayment capturedPayment =
+                subscriptionPaymentCaptor.getValue();
+
+        assertThat(capturedPayment.getSubscriptionId())
+                .isEqualTo(SUBSCRIPTION_ID);
+
+        assertThat(capturedPayment.getOrderId())
+                .isEqualTo(ORDER_ID);
+
+        assertThat(capturedPayment.getPaymentId())
+                .isEqualTo(PAYMENT_ID);
+
+        assertThat(capturedPayment.getUserId())
+                .isEqualTo(USER_ID);
+
+        assertThat(capturedPayment.getOrderNo())
+                .isEqualTo("ORD-SUBSCRIPTION-TEST");
+
+        assertThat(capturedPayment.getPlan())
+                .isEqualTo(SubscriptionPlan.MONTHLY);
+
+        assertThat(capturedPayment.getAmount())
+                .isEqualTo(MONTHLY_PRICE);
+
+        verifyNoInteractions(enrollmentPort);
+
+        verify(cartItemRepository, never())
+                .deleteAllSelectedByUserId(anyLong());
+
+        verify(cartItemRepository, never())
+                .deleteByUserIdAndCourseId(
+                        anyLong(),
+                        anyLong()
+                );
+    }
+
+    @Test
+    void checkout_subscription_rejects_active_subscription() {
+        when(subscriptionRepository.findActiveByUserId(
+                eq(USER_ID),
+                any(LocalDateTime.class)
+        )).thenReturn(
+                Optional.of(createSavedSubscription())
+        );
+
+        BusinessException exception =
+                catchThrowableOfType(
+                        () -> paymentCommandService.checkout(
+                                new PaymentCheckoutCommand(
+                                        USER_ID,
+                                        PaymentPurchaseType
+                                                .AI_SUBSCRIPTION,
+                                        null,
+                                        SubscriptionPlan.MONTHLY,
+                                        true
+                                )
+                        ),
+                        BusinessException.class
+                );
+
+        assertThat(exception.getErrorCode())
+                .isEqualTo(
+                        ErrorCode.SUBSCRIPTION_ALREADY_ACTIVE
+                );
+
+        verify(subscriptionRepository)
+                .findActiveByUserId(
+                        eq(USER_ID),
+                        any(LocalDateTime.class)
+                );
+
+        verifyNoInteractions(orderRepository);
+        verifyNoInteractions(orderItemRepository);
+        verifyNoInteractions(paymentRepository);
+        verifyNoInteractions(creditCommandUseCase);
+        verifyNoInteractions(subscriptionPaymentRepository);
+        verifyNoInteractions(enrollmentPort);
+    }
+
+    @Test
+    void checkout_subscription_requires_plan() {
+        BusinessException exception =
+                catchThrowableOfType(
+                        () -> paymentCommandService.checkout(
+                                new PaymentCheckoutCommand(
+                                        USER_ID,
+                                        PaymentPurchaseType
+                                                .AI_SUBSCRIPTION,
+                                        null,
+                                        null,
+                                        true
+                                )
+                        ),
+                        BusinessException.class
+                );
+
+        assertThat(exception.getErrorCode())
+                .isEqualTo(
+                        ErrorCode
+                                .PAYMENT_SUBSCRIPTION_PLAN_REQUIRED
+                );
+
+        verifyNoInteractions(subscriptionRepository);
+        verifyNoInteractions(subscriptionPaymentRepository);
+        verifyNoInteractions(orderRepository);
+        verifyNoInteractions(paymentRepository);
+        verifyNoInteractions(creditCommandUseCase);
+    }
+
+    @Test
+    void checkout_subscription_rejects_course_id() {
+        BusinessException exception =
+                catchThrowableOfType(
+                        () -> paymentCommandService.checkout(
+                                new PaymentCheckoutCommand(
+                                        USER_ID,
+                                        PaymentPurchaseType
+                                                .AI_SUBSCRIPTION,
+                                        COURSE_ID,
+                                        SubscriptionPlan.MONTHLY,
+                                        true
+                                )
+                        ),
+                        BusinessException.class
+                );
+
+        assertThat(exception.getErrorCode())
+                .isEqualTo(
+                        ErrorCode
+                                .PAYMENT_SUBSCRIPTION_COURSE_ID_NOT_ALLOWED
+                );
+
+        verifyNoInteractions(subscriptionRepository);
+        verifyNoInteractions(subscriptionPaymentRepository);
+        verifyNoInteractions(orderRepository);
+        verifyNoInteractions(paymentRepository);
+        verifyNoInteractions(creditCommandUseCase);
+    }
+
+    @Test
+    void checkout_course_rejects_subscription_plan() {
+        BusinessException exception =
+                catchThrowableOfType(
+                        () -> paymentCommandService.checkout(
+                                new PaymentCheckoutCommand(
+                                        USER_ID,
+                                        PaymentPurchaseType.COURSE,
+                                        COURSE_ID,
+                                        SubscriptionPlan.MONTHLY,
+                                        true
+                                )
+                        ),
+                        BusinessException.class
+                );
+
+        assertThat(exception.getErrorCode())
+                .isEqualTo(
+                        ErrorCode.PAYMENT_PLAN_NOT_ALLOWED
+                );
+
+        verifyNoInteractions(coursePurchasePolicy);
+        verifyNoInteractions(orderRepository);
+        verifyNoInteractions(paymentRepository);
+        verifyNoInteractions(creditCommandUseCase);
+    }
+
+    @Test
+    void checkout_cart_rejects_subscription_plan() {
+        BusinessException exception =
+                catchThrowableOfType(
+                        () -> paymentCommandService.checkout(
+                                new PaymentCheckoutCommand(
+                                        USER_ID,
+                                        PaymentPurchaseType.CART,
+                                        null,
+                                        SubscriptionPlan.MONTHLY,
+                                        true
+                                )
+                        ),
+                        BusinessException.class
+                );
+
+        assertThat(exception.getErrorCode())
+                .isEqualTo(
+                        ErrorCode.PAYMENT_PLAN_NOT_ALLOWED
+                );
+
+        verifyNoInteractions(cartItemRepository);
+        verifyNoInteractions(orderRepository);
+        verifyNoInteractions(paymentRepository);
+        verifyNoInteractions(creditCommandUseCase);
+    }
+
+    @Test
+    void checkout_cart_rejects_empty_selection() {
+        when(cartItemRepository.findAllSelectedByUserId(
+                USER_ID
+        )).thenReturn(List.of());
+
+        BusinessException exception =
+                catchThrowableOfType(
+                        () -> paymentCommandService.checkout(
+                                new PaymentCheckoutCommand(
+                                        USER_ID,
+                                        PaymentPurchaseType.CART,
+                                        null,
+                                        null,
+                                        true
+                                )
+                        ),
+                        BusinessException.class
+                );
 
         assertThat(exception.getErrorCode())
                 .isEqualTo(ErrorCode.CART_EMPTY_SELECTION);
 
-        verify(cartItemRepository)
-                .findAllSelectedByUserId(USER_ID);
         verifyNoInteractions(coursePurchasePolicy);
         verifyNoInteractions(orderRepository);
         verifyNoInteractions(orderItemRepository);
         verifyNoInteractions(paymentRepository);
         verifyNoInteractions(creditCommandUseCase);
         verifyNoInteractions(enrollmentPort);
-
-        verify(cartItemRepository, never())
-                .deleteAllSelectedByUserId(anyLong());
+        verifyNoInteractions(subscriptionRepository);
+        verifyNoInteractions(subscriptionPaymentRepository);
     }
 
     @Test
-    void 크레딧이_부족하면_수강_등록과_장바구니_삭제를_진행하지_않는다() {
+    void checkout_does_not_complete_course_when_credit_is_insufficient() {
         CourseInfo courseInfo = createCourseInfo();
-        Order savedOrder = createSavedOrder();
-        OrderItem savedOrderItem = createSavedOrderItem();
-        Payment savedPayment = createSavedPayment();
 
-        when(coursePurchasePolicy.validatePurchasable(USER_ID, COURSE_ID))
-                .thenReturn(courseInfo);
+        when(coursePurchasePolicy.validatePurchasable(
+                USER_ID,
+                COURSE_ID
+        )).thenReturn(courseInfo);
+
         when(orderRepository.save(any(Order.class)))
-                .thenReturn(savedOrder);
+                .thenReturn(createSavedCourseOrder());
+
         when(orderItemRepository.save(any(OrderItem.class)))
-                .thenReturn(savedOrderItem);
+                .thenReturn(createSavedCourseOrderItem());
+
         when(paymentRepository.save(any(Payment.class)))
-                .thenReturn(savedPayment);
+                .thenReturn(createSavedCoursePayment());
 
-        doThrow(new BusinessException(ErrorCode.CREDIT_INSUFFICIENT_BALANCE))
-                .when(creditCommandUseCase)
-                .useCredit(any(UseCreditCommand.class));
-
-        BusinessException exception = catchThrowableOfType(
-                () -> paymentCommandService.checkout(
-                        new PaymentCheckoutCommand(
-                                USER_ID,
-                                PaymentPurchaseType.COURSE,
-                                COURSE_ID,
-                                true
-                        )
-                ),
-                BusinessException.class
+        when(creditCommandUseCase.useCredit(
+                any(UseCreditCommand.class)
+        )).thenThrow(
+                new BusinessException(
+                        ErrorCode.CREDIT_INSUFFICIENT_BALANCE
+                )
         );
 
-        assertThat(exception.getErrorCode())
-                .isEqualTo(ErrorCode.CREDIT_INSUFFICIENT_BALANCE);
+        BusinessException exception =
+                catchThrowableOfType(
+                        () -> paymentCommandService.checkout(
+                                new PaymentCheckoutCommand(
+                                        USER_ID,
+                                        PaymentPurchaseType.COURSE,
+                                        COURSE_ID,
+                                        null,
+                                        true
+                                )
+                        ),
+                        BusinessException.class
+                );
 
-        verify(creditCommandUseCase)
-                .useCredit(any(UseCreditCommand.class));
+        assertThat(exception.getErrorCode())
+                .isEqualTo(
+                        ErrorCode.CREDIT_INSUFFICIENT_BALANCE
+                );
+
         verify(enrollmentPort, never())
-                .enrollPaidCourse(anyLong(), anyLong(), anyLong());
+                .enrollPaidCourse(
+                        anyLong(),
+                        anyLong(),
+                        anyLong()
+                );
+
         verify(cartItemRepository, never())
-                .deleteByUserIdAndCourseId(anyLong(), anyLong());
-        verify(cartItemRepository, never())
-                .deleteAllSelectedByUserId(anyLong());
+                .deleteByUserIdAndCourseId(
+                        anyLong(),
+                        anyLong()
+                );
     }
 
     @Test
-    void 결제에_동의하지_않으면_결제를_진행하지_않는다() {
-        BusinessException exception = catchThrowableOfType(
-                () -> paymentCommandService.checkout(
-                        new PaymentCheckoutCommand(
-                                USER_ID,
-                                PaymentPurchaseType.COURSE,
-                                COURSE_ID,
-                                false
-                        )
-                ),
-                BusinessException.class
+    void checkout_does_not_create_subscription_payment_when_credit_is_insufficient() {
+        when(subscriptionRepository.findActiveByUserId(
+                eq(USER_ID),
+                any(LocalDateTime.class)
+        )).thenReturn(Optional.empty());
+
+        when(orderRepository.save(any(Order.class)))
+                .thenReturn(createSavedSubscriptionOrder());
+
+        when(subscriptionRepository.save(
+                any(Subscription.class)
+        )).thenReturn(createSavedSubscription());
+
+        when(orderItemRepository.save(any(OrderItem.class)))
+                .thenReturn(
+                        createSavedSubscriptionOrderItem()
+                );
+
+        when(paymentRepository.save(any(Payment.class)))
+                .thenReturn(
+                        createSavedSubscriptionPayment()
+                );
+
+        when(creditCommandUseCase.useCredit(
+                any(UseCreditCommand.class)
+        )).thenThrow(
+                new BusinessException(
+                        ErrorCode.CREDIT_INSUFFICIENT_BALANCE
+                )
         );
 
+        BusinessException exception =
+                catchThrowableOfType(
+                        () -> paymentCommandService.checkout(
+                                new PaymentCheckoutCommand(
+                                        USER_ID,
+                                        PaymentPurchaseType
+                                                .AI_SUBSCRIPTION,
+                                        null,
+                                        SubscriptionPlan.MONTHLY,
+                                        true
+                                )
+                        ),
+                        BusinessException.class
+                );
+
         assertThat(exception.getErrorCode())
-                .isEqualTo(ErrorCode.PAYMENT_AGREEMENT_REQUIRED);
+                .isEqualTo(
+                        ErrorCode.CREDIT_INSUFFICIENT_BALANCE
+                );
+
+        verify(subscriptionPaymentRepository, never())
+                .save(any(SubscriptionPayment.class));
+
+        verifyNoInteractions(enrollmentPort);
+    }
+
+    @Test
+    void checkout_requires_agreement() {
+        BusinessException exception =
+                catchThrowableOfType(
+                        () -> paymentCommandService.checkout(
+                                new PaymentCheckoutCommand(
+                                        USER_ID,
+                                        PaymentPurchaseType.COURSE,
+                                        COURSE_ID,
+                                        null,
+                                        false
+                                )
+                        ),
+                        BusinessException.class
+                );
+
+        assertThat(exception.getErrorCode())
+                .isEqualTo(
+                        ErrorCode.PAYMENT_AGREEMENT_REQUIRED
+                );
 
         verifyNoInteractions(cartItemRepository);
         verifyNoInteractions(coursePurchasePolicy);
@@ -282,25 +806,31 @@ class PaymentCommandServiceTest {
         verifyNoInteractions(orderItemRepository);
         verifyNoInteractions(paymentRepository);
         verifyNoInteractions(creditCommandUseCase);
-        verifyNoInteractions(enrollmentPort);
+        verifyNoInteractions(subscriptionRepository);
+        verifyNoInteractions(subscriptionPaymentRepository);
     }
 
     @Test
-    void 구매_유형이_없으면_결제를_진행하지_않는다() {
-        BusinessException exception = catchThrowableOfType(
-                () -> paymentCommandService.checkout(
-                        new PaymentCheckoutCommand(
-                                USER_ID,
-                                null,
-                                COURSE_ID,
-                                true
-                        )
-                ),
-                BusinessException.class
-        );
+    void checkout_requires_purchase_type() {
+        BusinessException exception =
+                catchThrowableOfType(
+                        () -> paymentCommandService.checkout(
+                                new PaymentCheckoutCommand(
+                                        USER_ID,
+                                        null,
+                                        COURSE_ID,
+                                        null,
+                                        true
+                                )
+                        ),
+                        BusinessException.class
+                );
 
         assertThat(exception.getErrorCode())
-                .isEqualTo(ErrorCode.PAYMENT_INVALID_CHECKOUT_REQUEST);
+                .isEqualTo(
+                        ErrorCode
+                                .PAYMENT_INVALID_CHECKOUT_REQUEST
+                );
 
         verifyNoInteractions(cartItemRepository);
         verifyNoInteractions(coursePurchasePolicy);
@@ -308,85 +838,76 @@ class PaymentCommandServiceTest {
         verifyNoInteractions(orderItemRepository);
         verifyNoInteractions(paymentRepository);
         verifyNoInteractions(creditCommandUseCase);
-        verifyNoInteractions(enrollmentPort);
+        verifyNoInteractions(subscriptionRepository);
+        verifyNoInteractions(subscriptionPaymentRepository);
     }
 
     @Test
-    void 단일_강의_결제에는_courseId가_필요하다() {
-        BusinessException exception = catchThrowableOfType(
-                () -> paymentCommandService.checkout(
-                        new PaymentCheckoutCommand(
-                                USER_ID,
-                                PaymentPurchaseType.COURSE,
-                                null,
-                                true
-                        )
-                ),
-                BusinessException.class
-        );
+    void checkout_course_requires_positive_course_id() {
+        BusinessException nullIdException =
+                catchThrowableOfType(
+                        () -> paymentCommandService.checkout(
+                                new PaymentCheckoutCommand(
+                                        USER_ID,
+                                        PaymentPurchaseType.COURSE,
+                                        null,
+                                        null,
+                                        true
+                                )
+                        ),
+                        BusinessException.class
+                );
 
-        assertThat(exception.getErrorCode())
-                .isEqualTo(ErrorCode.PAYMENT_COURSE_ID_REQUIRED);
+        assertThat(nullIdException.getErrorCode())
+                .isEqualTo(
+                        ErrorCode.PAYMENT_COURSE_ID_REQUIRED
+                );
 
-        verifyNoInteractions(cartItemRepository);
-        verifyNoInteractions(coursePurchasePolicy);
-        verifyNoInteractions(orderRepository);
-        verifyNoInteractions(orderItemRepository);
-        verifyNoInteractions(paymentRepository);
-        verifyNoInteractions(creditCommandUseCase);
-        verifyNoInteractions(enrollmentPort);
+        BusinessException zeroIdException =
+                catchThrowableOfType(
+                        () -> paymentCommandService.checkout(
+                                new PaymentCheckoutCommand(
+                                        USER_ID,
+                                        PaymentPurchaseType.COURSE,
+                                        0L,
+                                        null,
+                                        true
+                                )
+                        ),
+                        BusinessException.class
+                );
+
+        assertThat(zeroIdException.getErrorCode())
+                .isEqualTo(
+                        ErrorCode.PAYMENT_COURSE_ID_REQUIRED
+                );
     }
 
     @Test
-    void 단일_강의_결제의_courseId가_양수가_아니면_결제할_수_없다() {
-        BusinessException exception = catchThrowableOfType(
-                () -> paymentCommandService.checkout(
-                        new PaymentCheckoutCommand(
-                                USER_ID,
-                                PaymentPurchaseType.COURSE,
-                                0L,
-                                true
-                        )
-                ),
-                BusinessException.class
-        );
+    void checkout_cart_rejects_course_id() {
+        BusinessException exception =
+                catchThrowableOfType(
+                        () -> paymentCommandService.checkout(
+                                new PaymentCheckoutCommand(
+                                        USER_ID,
+                                        PaymentPurchaseType.CART,
+                                        COURSE_ID,
+                                        null,
+                                        true
+                                )
+                        ),
+                        BusinessException.class
+                );
 
         assertThat(exception.getErrorCode())
-                .isEqualTo(ErrorCode.PAYMENT_COURSE_ID_REQUIRED);
+                .isEqualTo(
+                        ErrorCode
+                                .PAYMENT_CART_COURSE_ID_NOT_ALLOWED
+                );
 
         verifyNoInteractions(cartItemRepository);
-        verifyNoInteractions(coursePurchasePolicy);
         verifyNoInteractions(orderRepository);
-        verifyNoInteractions(orderItemRepository);
         verifyNoInteractions(paymentRepository);
-        verifyNoInteractions(creditCommandUseCase);
-        verifyNoInteractions(enrollmentPort);
-    }
-
-    @Test
-    void 장바구니_결제에는_courseId를_전달할_수_없다() {
-        BusinessException exception = catchThrowableOfType(
-                () -> paymentCommandService.checkout(
-                        new PaymentCheckoutCommand(
-                                USER_ID,
-                                PaymentPurchaseType.CART,
-                                COURSE_ID,
-                                true
-                        )
-                ),
-                BusinessException.class
-        );
-
-        assertThat(exception.getErrorCode())
-                .isEqualTo(ErrorCode.PAYMENT_CART_COURSE_ID_NOT_ALLOWED);
-
-        verifyNoInteractions(cartItemRepository);
-        verifyNoInteractions(coursePurchasePolicy);
-        verifyNoInteractions(orderRepository);
-        verifyNoInteractions(orderItemRepository);
-        verifyNoInteractions(paymentRepository);
-        verifyNoInteractions(creditCommandUseCase);
-        verifyNoInteractions(enrollmentPort);
     }
 
     private CartItem createCartItem() {
@@ -411,7 +932,7 @@ class PaymentCommandServiceTest {
         );
     }
 
-    private Order createSavedOrder() {
+    private Order createSavedCourseOrder() {
         return Order.restore(
                 ORDER_ID,
                 "ORD-TEST",
@@ -424,7 +945,20 @@ class PaymentCommandServiceTest {
         );
     }
 
-    private OrderItem createSavedOrderItem() {
+    private Order createSavedSubscriptionOrder() {
+        return Order.restore(
+                ORDER_ID,
+                "ORD-SUBSCRIPTION-TEST",
+                MONTHLY_PRICE,
+                0L,
+                MONTHLY_PRICE,
+                OrderStatus.PAID,
+                LocalDateTime.now(),
+                USER_ID
+        );
+    }
+
+    private OrderItem createSavedCourseOrderItem() {
         return OrderItem.restore(
                 ORDER_ITEM_ID,
                 "Spring Boot Basic",
@@ -436,14 +970,62 @@ class PaymentCommandServiceTest {
         );
     }
 
-    private Payment createSavedPayment() {
+    private OrderItem createSavedSubscriptionOrderItem() {
+        return OrderItem.restore(
+                SUBSCRIPTION_ORDER_ITEM_ID,
+                OrderItemType.AI_SUBSCRIPTION,
+                SUBSCRIPTION_ID,
+                "1개월 플랜",
+                MONTHLY_PRICE,
+                0L,
+                MONTHLY_PRICE,
+                ORDER_ID,
+                null
+        );
+    }
+
+    private Payment createSavedCoursePayment() {
+        LocalDateTime now = LocalDateTime.now();
+
         return Payment.restore(
                 PAYMENT_ID,
                 COURSE_PRICE,
                 PaymentStatus.PAID,
-                LocalDateTime.now(),
-                LocalDateTime.now(),
+                now,
+                now,
                 ORDER_ID,
+                USER_ID
+        );
+    }
+
+    private Payment createSavedSubscriptionPayment() {
+        LocalDateTime now = LocalDateTime.now();
+
+        return Payment.restore(
+                PAYMENT_ID,
+                MONTHLY_PRICE,
+                PaymentStatus.PAID,
+                now,
+                now,
+                ORDER_ID,
+                USER_ID
+        );
+    }
+
+    private Subscription createSavedSubscription() {
+        LocalDateTime startedAt = LocalDateTime.now();
+        LocalDateTime expiredAt =
+                startedAt.plusMonths(1);
+
+        return Subscription.restore(
+                SUBSCRIPTION_ID,
+                SubscriptionPlan.MONTHLY,
+                SubscriptionStatus.ACTIVE,
+                MONTHLY_PRICE,
+                startedAt,
+                expiredAt,
+                expiredAt,
+                true,
                 USER_ID
         );
     }


### PR DESCRIPTION
## 📌 PR 요약
AI 구독권 월간/연간 플랜 조회와 크레딧 결제 기능을 구현했습니다.
기존 공통 결제 API를 확장해 강의, 장바구니, AI 구독권 결제를 상품 유형에 따라 처리하도록 변경했습니다.

---

## 🛠️ 작업 상세 내용 (체크로 선택)
- [x] ✨ FEATURE
- [ ] 🔧 UPDATE
- [ ] 🐛 BUGFIX
- [ ] ♻️ REFACTOR
- [ ] 📝 DOCS

---

## 📋 작업 상세 내용
AI 구독 플랜 및 구독 결제 이력 DB 스키마 추가
구독 플랜·결제 전 정보·현재 구독·결제 내역 조회 API 구현
공통 결제 API에 AI_SUBSCRIPTION 유형 추가
구독 결제 시 주문, 결제, 크레딧 차감 및 구독 활성화 처리
강의 결제 내역과 구독 결제 내역 분리
기존 강의·장바구니 결제 회귀 테스트 및 구독 결제 테스트 추가
---

## 🔗 PR 관련 이슈로 닫기
Closes #181 

---

## ✅ 체크리스트 (확인 절차)
- [x] 정상적으로 빌드 및 실행됩니다.
- [x] 주요 기능이 정상 동작합니다.
- [ ] 불필요한 코드를 제거했습니다.
- [ ] 코드 리뷰 준비가 완료되었습니다.

---

## 💬 리뷰어에게 할 말

---

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added subscription purchase option supporting monthly and annual plans with flexible billing
  * Added subscription management features: view available plans, preview pricing and credits before purchase, check current subscription status, and view subscription payment history

* **Tests**
  * Extended test coverage to validate subscription checkout workflow and payment processing

<!-- end of auto-generated comment: release notes by coderabbit.ai -->