### PR TITLE
{UPDATE} #293, #294 크레딧 원장 도입 및 결제 멱등성 강화

### DIFF
--- a/src/main/java/com/sashimi/credit/application/service/CreditChargeTransactionService.java
+++ b/src/main/java/com/sashimi/credit/application/service/CreditChargeTransactionService.java
@@ -1,0 +1,114 @@
+package com.sashimi.credit.application.service;
+
+import com.sashimi.credit.application.command.ConfirmCreditChargeCommand;
+import com.sashimi.credit.application.result.CreditChargeConfirmResult;
+import com.sashimi.credit.domain.model.Credit;
+import com.sashimi.credit.domain.model.CreditChargePayment;
+import com.sashimi.credit.domain.repository.CreditChargePaymentRepository;
+import com.sashimi.credit.domain.repository.CreditRepository;
+import com.sashimi.credit.infrastructure.toss.TossPaymentConfirmResponse;
+import com.sashimi.global.exception.BusinessException;
+import com.sashimi.global.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class CreditChargeTransactionService {
+
+    private final CreditRepository creditRepository;
+    private final CreditChargePaymentRepository paymentRepository;
+
+    @Transactional
+    public CreditChargeConfirmResult complete(
+            ConfirmCreditChargeCommand command,
+            TossPaymentConfirmResponse response
+    ) {
+        CreditChargePayment payment =
+                paymentRepository.findByOrderIdForUpdate(command.orderId())
+                        .orElseThrow(() -> new BusinessException(
+                                ErrorCode.CREDIT_CHARGE_PAYMENT_NOT_FOUND
+                        ));
+
+        payment.validateOwner(command.userId());
+        payment.validateAmount(command.amount());
+
+        if (payment.isDone()) {
+            payment.validatePaymentKey(command.paymentKey());
+            return createCompletedResult(payment);
+        }
+
+        payment.markDone(
+                response.paymentKey(),
+                response.method(),
+                response.approvedAt() == null
+                        ? null
+                        : response.approvedAt().toLocalDateTime()
+        );
+
+        paymentRepository.save(payment);
+
+        Credit credit = creditRepository
+                .findByUserIdForUpdate(command.userId())
+                .orElseGet(() -> Credit.create(command.userId(), 0L));
+
+        credit.add(payment.getAmount());
+
+        Credit savedCredit = creditRepository.save(credit);
+
+        log.info(
+                "크레딧 토스 충전 완료 - userId={}, orderId={}, paymentMethod={}, amount={}, balance={}",
+                command.userId(),
+                payment.getOrderId(),
+                payment.getPaymentMethod(),
+                payment.getAmount(),
+                savedCredit.getBalance()
+        );
+
+        return new CreditChargeConfirmResult(
+                savedCredit.getBalance(),
+                payment.getOrderId(),
+                payment.getPaymentKey(),
+                payment.getAmount()
+        );
+    }
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void markFailed(
+            ConfirmCreditChargeCommand command,
+            String failureReason
+    ) {
+        CreditChargePayment payment =
+                paymentRepository.findByOrderIdForUpdate(command.orderId())
+                        .orElseThrow(() -> new BusinessException(
+                                ErrorCode.CREDIT_CHARGE_PAYMENT_NOT_FOUND
+                        ));
+
+        if (payment.isDone()) {
+            return;
+        }
+
+        payment.markFailed(failureReason);
+        paymentRepository.save(payment);
+    }
+
+    private CreditChargeConfirmResult createCompletedResult(
+            CreditChargePayment payment
+    ) {
+        Credit credit = creditRepository.findByUserId(payment.getUserId())
+                .orElseThrow(() -> new BusinessException(
+                        ErrorCode.CREDIT_CHARGE_RESULT_INCONSISTENT
+                ));
+
+        return new CreditChargeConfirmResult(
+                credit.getBalance(),
+                payment.getOrderId(),
+                payment.getPaymentKey(),
+                payment.getAmount()
+        );
+    }
+}

--- a/src/main/java/com/sashimi/credit/application/service/CreditCommandService.java
+++ b/src/main/java/com/sashimi/credit/application/service/CreditCommandService.java
@@ -19,6 +19,8 @@ import com.sashimi.credit.infrastructure.toss.TossPaymentConfirmResponse;
 import com.sashimi.global.exception.BusinessException;
 import com.sashimi.global.exception.ErrorCode;
 
+import java.util.Objects;
+import org.springframework.transaction.annotation.Propagation;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -41,6 +43,7 @@ public class CreditCommandService implements CreditCommandUseCase {
     private final CreditChargePolicy creditChargePolicy;
     private final CreditChargePaymentRepository creditChargePaymentRepository;
     private final TossPaymentClient tossPaymentClient;
+    private final CreditChargeTransactionService creditChargeTransactionService;
 
     @Override
     public void createInitialCredit(CreateInitialCreditCommand command) {
@@ -117,15 +120,24 @@ public class CreditCommandService implements CreditCommandUseCase {
     }
 
     @Override
+    @Transactional(propagation = Propagation.NOT_SUPPORTED)
     public CreditChargeConfirmResult confirmCreditCharge(ConfirmCreditChargeCommand command) {
-        CreditChargePayment payment = creditChargePaymentRepository.findByOrderIdForUpdate(command.orderId())
-                .orElseThrow(() -> new BusinessException(ErrorCode.CREDIT_CHARGE_PAYMENT_NOT_FOUND));
+        CreditChargePayment payment =
+                creditChargePaymentRepository.findByOrderId(command.orderId())
+                        .orElseThrow(() -> new BusinessException(
+                                ErrorCode.CREDIT_CHARGE_PAYMENT_NOT_FOUND
+                        ));
 
         payment.validateOwner(command.userId());
         payment.validateAmount(command.amount());
 
         if (payment.isDone()) {
-            Credit credit = getOrCreateCreditForUpdate(command.userId());
+            payment.validatePaymentKey(command.paymentKey());
+
+            Credit credit = creditRepository.findByUserId(command.userId())
+                    .orElseThrow(() -> new BusinessException(
+                            ErrorCode.CREDIT_CHARGE_RESULT_INCONSISTENT
+                    ));
 
             return new CreditChargeConfirmResult(
                     credit.getBalance(),
@@ -135,60 +147,46 @@ public class CreditCommandService implements CreditCommandUseCase {
             );
         }
 
-        TossPaymentConfirmResponse tossResponse;
-
-        try {
-            tossResponse = tossPaymentClient.confirm(
-                    command.paymentKey(),
-                    command.orderId(),
-                    command.amount()
+        if (payment.isFailed()) {
+            throw new BusinessException(
+                    ErrorCode.CREDIT_CHARGE_PAYMENT_ALREADY_PROCESSED
             );
-        } catch (BusinessException e) {
-            throw e;
         }
 
-        if (tossResponse == null || !"DONE".equals(tossResponse.status())) {
-            payment.markFailed("Toss payment approval failed");
-            creditChargePaymentRepository.save(payment);
+        TossPaymentConfirmResponse response =
+                tossPaymentClient.confirmOrRetrieve(
+                        command.paymentKey(),
+                        command.orderId(),
+                        command.amount()
+                );
+
+        validateTossResponse(command, response);
+
+        return creditChargeTransactionService.complete(command, response);
+    }
+
+    private void validateTossResponse(ConfirmCreditChargeCommand command, TossPaymentConfirmResponse response) {
+        if (response == null || !"DONE".equals(response.status())) {
+            creditChargeTransactionService.markFailed(command, "Toss payment status is not DONE");
+
             throw new BusinessException(ErrorCode.CREDIT_EXTERNAL_PAYMENT_FAILED);
         }
 
-        if (!command.amount().equals(tossResponse.totalAmount())) {
-            payment.markFailed("Toss payment amount mismatch");
-            creditChargePaymentRepository.save(payment);
-            throw new BusinessException(ErrorCode.CREDIT_CHARGE_PAYMENT_AMOUNT_MISMATCH);
+        if (!Objects.equals(command.orderId(), response.orderId())
+                || !Objects.equals(
+                command.paymentKey(),
+                response.paymentKey()
+        )) {
+            creditChargeTransactionService.markFailed(command, "Toss payment identifier mismatch");
+
+            throw new BusinessException(ErrorCode.CREDIT_EXTERNAL_PAYMENT_RESPONSE_MISMATCH);
         }
 
-        payment.markDone(
-                tossResponse.paymentKey(),
-                tossResponse.method(),
-                tossResponse.approvedAt() == null
-                        ? null
-                        : tossResponse.approvedAt().toLocalDateTime()
-        );
-        creditChargePaymentRepository.save(payment);
+        if (!Objects.equals(command.amount(), response.totalAmount())) {
+            creditChargeTransactionService.markFailed(command, "Toss payment amount mismatch");
 
-        Credit credit = getOrCreateCreditForUpdate(command.userId());
-        credit.add(payment.getAmount());
-
-        Credit savedCredit = creditRepository.save(credit);
-
-        log.info(
-                "크레딧 토스 충전 완료 - userId={}, orderId={}, paymentKey={}, paymentMethod={}, amount={}, balance={}",
-                command.userId(),
-                payment.getOrderId(),
-                payment.getPaymentKey(),
-                payment.getPaymentMethod(),
-                payment.getAmount(),
-                savedCredit.getBalance()
-        );
-
-        return new CreditChargeConfirmResult(
-                savedCredit.getBalance(),
-                payment.getOrderId(),
-                payment.getPaymentKey(),
-                payment.getAmount()
-        );
+            throw new BusinessException(ErrorCode.CREDIT_CHARGE_PAYMENT_AMOUNT_MISMATCH);
+        }
     }
 
     private String generateCreditChargeOrderId() {

--- a/src/main/java/com/sashimi/credit/domain/model/CreditChargePayment.java
+++ b/src/main/java/com/sashimi/credit/domain/model/CreditChargePayment.java
@@ -100,6 +100,15 @@ public class CreditChargePayment {
         }
     }
 
+    public void validatePaymentKey(String paymentKey) {
+        if (this.paymentKey == null
+                || !this.paymentKey.equals(paymentKey)) {
+            throw new BusinessException(
+                    ErrorCode.CREDIT_EXTERNAL_PAYMENT_RESPONSE_MISMATCH
+            );
+        }
+    }
+
     public void markDone(
             String paymentKey,
             String paymentMethod,
@@ -130,6 +139,10 @@ public class CreditChargePayment {
 
         this.status = CreditChargePaymentStatus.FAILED;
         this.failureReason = failureReason;
+    }
+
+    public boolean isFailed() {
+        return status == CreditChargePaymentStatus.FAILED;
     }
 
     public boolean isDone() {

--- a/src/main/java/com/sashimi/credit/infrastructure/toss/TossPaymentClient.java
+++ b/src/main/java/com/sashimi/credit/infrastructure/toss/TossPaymentClient.java
@@ -2,42 +2,75 @@ package com.sashimi.credit.infrastructure.toss;
 
 import com.sashimi.global.exception.BusinessException;
 import com.sashimi.global.exception.ErrorCode;
-import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpHeaders;
-import org.springframework.http.MediaType;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestClient;
 import org.springframework.web.client.RestClientException;
 
-import java.nio.charset.StandardCharsets;
-import java.util.Base64;
-
+@Slf4j
 @Component
-@RequiredArgsConstructor
 public class TossPaymentClient {
 
-    private final TossPaymentProperties properties;
+    private final RestClient restClient;
 
-    public TossPaymentConfirmResponse confirm(String paymentKey, String orderId, Long amount) {
+    public TossPaymentClient(
+            @Qualifier("tossPaymentRestClient") RestClient restClient
+    ) {
+        this.restClient = restClient;
+    }
+
+    public TossPaymentConfirmResponse confirmOrRetrieve(
+            String paymentKey,
+            String orderId,
+            Long amount
+    ) {
         try {
-            return RestClient.builder()
-                    .baseUrl(properties.baseUrl())
-                    .defaultHeader(HttpHeaders.AUTHORIZATION, authorizationHeader())
-                    .defaultHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
-                    .build()
-                    .post()
-                    .uri("/v1/payments/confirm")
-                    .body(new TossPaymentConfirmRequest(paymentKey, orderId, amount))
-                    .retrieve()
-                    .body(TossPaymentConfirmResponse.class);
-        } catch (RestClientException e) {
-            throw new BusinessException(ErrorCode.CREDIT_EXTERNAL_PAYMENT_FAILED);
+            return confirm(paymentKey, orderId, amount);
+        } catch (RestClientException confirmException) {
+            log.warn(
+                    "토스 결제 승인 응답 확인 실패, 결제 조회로 복구 시도 - orderId={}",
+                    orderId
+            );
+
+            return retrieveApprovedPayment(paymentKey, orderId);
         }
     }
 
-    private String authorizationHeader() {
-        String raw = properties.secretKey() + ":";
-        String encoded = Base64.getEncoder().encodeToString(raw.getBytes(StandardCharsets.UTF_8));
-        return "Basic " + encoded;
+    private TossPaymentConfirmResponse confirm(
+            String paymentKey,
+            String orderId,
+            Long amount
+    ) {
+        return restClient.post()
+                .uri("/v1/payments/confirm")
+                .body(new TossPaymentConfirmRequest(
+                        paymentKey,
+                        orderId,
+                        amount
+                ))
+                .retrieve()
+                .requiredBody(TossPaymentConfirmResponse.class);
+    }
+
+    private TossPaymentConfirmResponse retrieveApprovedPayment(
+            String paymentKey,
+            String orderId
+    ) {
+        try {
+            return restClient.get()
+                    .uri("/v1/payments/{paymentKey}", paymentKey)
+                    .retrieve()
+                    .requiredBody(TossPaymentConfirmResponse.class);
+        } catch (RestClientException retrieveException) {
+            log.error(
+                    "토스 결제 승인 및 조회 모두 실패 - orderId={}",
+                    orderId
+            );
+
+            throw new BusinessException(
+                    ErrorCode.CREDIT_EXTERNAL_PAYMENT_FAILED
+            );
+        }
     }
 }

--- a/src/main/java/com/sashimi/credit/infrastructure/toss/TossPaymentConfig.java
+++ b/src/main/java/com/sashimi/credit/infrastructure/toss/TossPaymentConfig.java
@@ -1,9 +1,58 @@
 package com.sashimi.credit.infrastructure.toss;
 
+import java.net.http.HttpClient;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.http.client.JdkClientHttpRequestFactory;
+import org.springframework.web.client.RestClient;
 
 @Configuration
 @EnableConfigurationProperties(TossPaymentProperties.class)
 public class TossPaymentConfig {
+
+    @Bean
+    public RestClient tossPaymentRestClient(
+            TossPaymentProperties properties
+    ) {
+        HttpClient httpClient = HttpClient.newBuilder()
+                .connectTimeout(properties.connectTimeout())
+                .build();
+
+        JdkClientHttpRequestFactory requestFactory =
+                new JdkClientHttpRequestFactory(httpClient);
+
+        requestFactory.setReadTimeout(properties.readTimeout());
+
+        return RestClient.builder()
+                .baseUrl(properties.baseUrl())
+                .requestFactory(requestFactory)
+                .defaultHeader(
+                        HttpHeaders.AUTHORIZATION,
+                        createAuthorizationHeader(properties.secretKey())
+                )
+                .defaultHeader(
+                        HttpHeaders.CONTENT_TYPE,
+                        MediaType.APPLICATION_JSON_VALUE
+                )
+                .defaultHeader(
+                        HttpHeaders.ACCEPT,
+                        MediaType.APPLICATION_JSON_VALUE
+                )
+                .build();
+    }
+
+    private String createAuthorizationHeader(String secretKey) {
+        String credentials = secretKey + ":";
+
+        String encoded = Base64.getEncoder().encodeToString(
+                credentials.getBytes(StandardCharsets.UTF_8)
+        );
+
+        return "Basic " + encoded;
+    }
 }

--- a/src/main/java/com/sashimi/credit/infrastructure/toss/TossPaymentProperties.java
+++ b/src/main/java/com/sashimi/credit/infrastructure/toss/TossPaymentProperties.java
@@ -1,6 +1,8 @@
 package com.sashimi.credit.infrastructure.toss;
 
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import java.time.Duration;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.validation.annotation.Validated;
 
@@ -8,6 +10,8 @@ import org.springframework.validation.annotation.Validated;
 @ConfigurationProperties(prefix = "toss.payments")
 public record TossPaymentProperties(
         @NotBlank String baseUrl,
-        @NotBlank String secretKey
+        @NotBlank String secretKey,
+        @NotNull Duration connectTimeout,
+        @NotNull Duration readTimeout
 ) {
 }

--- a/src/main/java/com/sashimi/global/exception/ErrorCode.java
+++ b/src/main/java/com/sashimi/global/exception/ErrorCode.java
@@ -82,6 +82,8 @@ public enum ErrorCode {
     CREDIT_CHARGE_PAYMENT_AMOUNT_MISMATCH(400, "CREDIT_007", "크레딧 충전 결제 금액이 일치하지 않습니다."),
     CREDIT_CHARGE_PAYMENT_FORBIDDEN(403, "CREDIT_008", "해당 크레딧 충전 결제에 접근할 수 없습니다."),
     CREDIT_EXTERNAL_PAYMENT_FAILED(502, "CREDIT_009", "외부 결제 승인에 실패했습니다."),
+    CREDIT_EXTERNAL_PAYMENT_RESPONSE_MISMATCH(502, "CREDIT_010", "외부 결제 승인 정보가 요청 정보와 일치하지 않습니다."),
+    CREDIT_CHARGE_RESULT_INCONSISTENT(500, "CREDIT_011", "승인된 크레딧 충전 결과의 정합성을 확인할 수 없습니다."),
 
     SUBSCRIPTION_NOT_FOUND(404, "SUBSCRIPTION_001", "구독권을 찾을 수 없습니다."),
     SUBSCRIPTION_ALREADY_ACTIVE(409, "SUBSCRIPTION_002", "이미 활성화된 구독권이 있습니다."),

--- a/src/main/java/com/sashimi/global/exception/ErrorCode.java
+++ b/src/main/java/com/sashimi/global/exception/ErrorCode.java
@@ -72,6 +72,11 @@ public enum ErrorCode {
     PAYMENT_SUBSCRIPTION_PLAN_REQUIRED(400, "PAYMENT_012", "구독권 결제에는 구독 플랜이 필요합니다."),
     PAYMENT_PLAN_NOT_ALLOWED(400, "PAYMENT_013", "강의 또는 장바구니 결제에는 구독 플랜을 전달할 수 없습니다."),
     PAYMENT_SUBSCRIPTION_COURSE_ID_NOT_ALLOWED(400, "PAYMENT_014", "구독권 결제에는 강의 ID를 전달할 수 없습니다."),
+    PAYMENT_IDEMPOTENCY_KEY_INVALID(400, "PAYMENT_015", "결제 멱등성 키가 올바르지 않습니다."),
+    PAYMENT_IDEMPOTENCY_KEY_CONFLICT(409, "PAYMENT_016", "동일한 멱등성 키가 다른 결제 요청에 사용되었습니다."),
+    PAYMENT_IDEMPOTENCY_PROCESSING(409, "PAYMENT_017", "동일한 결제 요청이 처리 중입니다."),
+    PAYMENT_IDEMPOTENCY_RESULT_INVALID(500, "PAYMENT_018", "기존 결제 결과를 복원할 수 없습니다."),
+    PAYMENT_IDEMPOTENCY_FAILED(409, "PAYMENT_019", "이전에 실패한 결제 요청입니다. 새로운 멱등성 키로 다시 요청해 주세요."),
 
     CREDIT_INVALID_AMOUNT(400, "CREDIT_001", "크레딧 금액이 올바르지 않습니다."),
     CREDIT_INSUFFICIENT_BALANCE(400, "CREDIT_002", "크레딧 잔액이 부족합니다."),

--- a/src/main/java/com/sashimi/order/domain/model/Order.java
+++ b/src/main/java/com/sashimi/order/domain/model/Order.java
@@ -14,7 +14,8 @@ public class Order {
     private final Long userId;
 
     private Order(Long id, String orderNo, Long totalAmount, Long discountAmount,
-                  Long finalAmount, OrderStatus status, LocalDateTime createdAt, Long userId) {
+                  Long finalAmount, OrderStatus status, LocalDateTime createdAt, Long userId
+    ) {
         this.id = id;
         this.orderNo = orderNo;
         this.totalAmount = totalAmount;

--- a/src/main/java/com/sashimi/payment/application/command/PaymentCheckoutCommand.java
+++ b/src/main/java/com/sashimi/payment/application/command/PaymentCheckoutCommand.java
@@ -3,12 +3,11 @@ package com.sashimi.payment.application.command;
 import com.sashimi.subscription.domain.model.SubscriptionPlan;
 
 public record PaymentCheckoutCommand(
-
         Long userId,
         PaymentPurchaseType purchaseType,
         Long courseId,
         SubscriptionPlan planCode,
-        Boolean agreed
-
+        Boolean agreed,
+        String idempotencyKey
 ) {
 }

--- a/src/main/java/com/sashimi/payment/application/service/PaymentCheckoutTransactionService.java
+++ b/src/main/java/com/sashimi/payment/application/service/PaymentCheckoutTransactionService.java
@@ -1,0 +1,378 @@
+package com.sashimi.payment.application.service;
+
+import com.sashimi.cart.application.port.CourseInfo;
+import com.sashimi.cart.domain.model.CartItem;
+import com.sashimi.cart.domain.repository.CartItemRepository;
+import com.sashimi.credit.application.command.UseCreditCommand;
+import com.sashimi.credit.application.result.CreditBalanceResult;
+import com.sashimi.credit.application.usecase.CreditCommandUseCase;
+import com.sashimi.enrollment.application.port.EnrollmentPort;
+import com.sashimi.global.exception.BusinessException;
+import com.sashimi.global.exception.ErrorCode;
+import com.sashimi.order.application.policy.CoursePurchasePolicy;
+import com.sashimi.order.domain.model.Order;
+import com.sashimi.order.domain.model.OrderItem;
+import com.sashimi.order.domain.repository.OrderItemRepository;
+import com.sashimi.order.domain.repository.OrderRepository;
+import com.sashimi.payment.application.command.PaymentCheckoutCommand;
+import com.sashimi.payment.application.command.PaymentPurchaseType;
+import com.sashimi.payment.domain.model.Payment;
+import com.sashimi.payment.domain.repository.PaymentRepository;
+import com.sashimi.subscription.domain.model.Subscription;
+import com.sashimi.subscription.domain.model.SubscriptionPayment;
+import com.sashimi.subscription.domain.model.SubscriptionPlan;
+import com.sashimi.subscription.domain.repository.SubscriptionPaymentRepository;
+import com.sashimi.subscription.domain.repository.SubscriptionRepository;
+import com.sashimi.payment.application.usecase.PaymentCommandUseCase.PaymentResult;
+import com.sashimi.payment.application.usecase.PaymentCommandUseCase.PaidCourse;
+import com.sashimi.payment.application.usecase.PaymentCommandUseCase.PaidSubscription;
+import com.sashimi.payment.domain.model.PaymentIdempotency;
+import com.sashimi.payment.domain.repository.PaymentIdempotencyRepository;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+import java.util.UUID;
+
+@Slf4j
+@Service
+@Transactional
+public class PaymentCheckoutTransactionService {
+
+    private final CartItemRepository cartItemRepository;
+    private final CoursePurchasePolicy coursePurchasePolicy;
+    private final EnrollmentPort enrollmentPort;
+    private final OrderRepository orderRepository;
+    private final OrderItemRepository orderItemRepository;
+    private final PaymentRepository paymentRepository;
+    private final CreditCommandUseCase creditCommandUseCase;
+    private final SubscriptionRepository subscriptionRepository;
+    private final SubscriptionPaymentRepository subscriptionPaymentRepository;
+    private final PaymentIdempotencyRepository paymentIdempotencyRepository;
+    private final PaymentResultJsonCodec paymentResultJsonCodec;
+
+    public PaymentCheckoutTransactionService(
+            CartItemRepository cartItemRepository, CoursePurchasePolicy coursePurchasePolicy,
+            EnrollmentPort enrollmentPort, OrderRepository orderRepository,
+            OrderItemRepository orderItemRepository, PaymentRepository paymentRepository,
+            CreditCommandUseCase creditCommandUseCase, SubscriptionRepository subscriptionRepository,
+            SubscriptionPaymentRepository subscriptionPaymentRepository,PaymentIdempotencyRepository paymentIdempotencyRepository,
+            PaymentResultJsonCodec paymentResultJsonCodec
+    ) {
+        this.cartItemRepository = cartItemRepository;
+        this.coursePurchasePolicy = coursePurchasePolicy;
+        this.enrollmentPort = enrollmentPort;
+        this.orderRepository = orderRepository;
+        this.orderItemRepository = orderItemRepository;
+        this.paymentRepository = paymentRepository;
+        this.creditCommandUseCase = creditCommandUseCase;
+        this.subscriptionRepository = subscriptionRepository;
+        this.subscriptionPaymentRepository = subscriptionPaymentRepository;
+        this.paymentIdempotencyRepository = paymentIdempotencyRepository;
+        this.paymentResultJsonCodec = paymentResultJsonCodec;
+    }
+
+    public PaymentResult execute(
+            PaymentCheckoutCommand command,
+            Long idempotencyId
+    ) {
+        validateCheckoutRequest(command);
+
+        PaymentResult result = switch (command.purchaseType()) {
+            case COURSE -> {
+                validateCourseRequest(command);
+                yield checkoutCourse(
+                        command.userId(),
+                        command.courseId()
+                );
+            }
+
+            case CART -> {
+                validateCartRequest(command);
+                yield checkoutCart(command.userId());
+            }
+
+            case AI_SUBSCRIPTION -> {
+                validateSubscriptionRequest(command);
+                yield checkoutSubscription(
+                        command.userId(),
+                        command.planCode()
+                );
+            }
+        };
+
+        PaymentIdempotency idempotency =
+                paymentIdempotencyRepository
+                        .findByIdForUpdate(idempotencyId)
+                        .orElseThrow(() -> new BusinessException(
+                                ErrorCode.PAYMENT_IDEMPOTENCY_RESULT_INVALID
+                        ));
+
+        idempotency.complete(
+                paymentResultJsonCodec.serialize(result)
+        );
+
+        paymentIdempotencyRepository.save(idempotency);
+
+        return result;
+    }
+
+    private void validateCourseRequest(
+            PaymentCheckoutCommand command
+    ) {
+        if (command.courseId() == null
+                || command.courseId() <= 0) {
+            throw new BusinessException(
+                    ErrorCode.PAYMENT_COURSE_ID_REQUIRED);
+        }
+
+        if (command.planCode() != null) {
+            throw new BusinessException(
+                    ErrorCode.PAYMENT_PLAN_NOT_ALLOWED);
+        }
+    }
+
+    private void validateCartRequest(
+            PaymentCheckoutCommand command
+    ) {
+        if (command.courseId() != null) {
+            throw new BusinessException(
+                    ErrorCode.PAYMENT_CART_COURSE_ID_NOT_ALLOWED);
+        }
+
+        if (command.planCode() != null) {
+            throw new BusinessException(
+                    ErrorCode.PAYMENT_PLAN_NOT_ALLOWED);
+        }
+    }
+    private void validateCheckoutRequest(
+            PaymentCheckoutCommand command
+    ) {
+        if (!Boolean.TRUE.equals(command.agreed())) {
+            throw new BusinessException(
+                    ErrorCode.PAYMENT_AGREEMENT_REQUIRED
+            );
+        }
+
+        if (command.purchaseType() == null) {
+            throw new BusinessException(
+                    ErrorCode.PAYMENT_INVALID_CHECKOUT_REQUEST
+            );
+        }
+    }
+
+    private void validateSubscriptionRequest(
+            PaymentCheckoutCommand command
+    ) {
+        if (command.courseId() != null) {
+            throw new BusinessException(
+                    ErrorCode
+                            .PAYMENT_SUBSCRIPTION_COURSE_ID_NOT_ALLOWED);
+        }
+
+        if (command.planCode() == null) {
+            throw new BusinessException(
+                    ErrorCode.PAYMENT_SUBSCRIPTION_PLAN_REQUIRED);
+        }
+    }
+
+    private PaymentResult checkoutCourse(Long userId, Long courseId) {
+        CourseInfo course =
+                coursePurchasePolicy.validatePurchasable(
+                        userId,
+                        courseId);
+
+        PaymentResult result = payCourses(
+                userId,
+                List.of(
+                        new PaymentCourse(
+                                course.courseId(),
+                                course.title(),
+                                course.price())
+                ),
+                PaymentSource.DIRECT);
+
+        cartItemRepository.deleteByUserIdAndCourseId(userId, courseId);
+
+        return result;
+    }
+
+    private PaymentResult checkoutCart(Long userId) {
+        List<CartItem> cartItems =
+                cartItemRepository.findAllSelectedByUserId(
+                        userId);
+
+        if (cartItems.isEmpty()) {
+            throw new BusinessException(
+                    ErrorCode.CART_EMPTY_SELECTION);
+        }
+
+        List<PaymentCourse> courses = cartItems.stream().map(item -> coursePurchasePolicy.validatePurchasable(
+                userId, item.getCourseId()))
+                .map(course -> new PaymentCourse(course.courseId(), course.title(), course.price()))
+                .toList();
+        return payCourses(userId, courses, PaymentSource.CART);
+    }
+
+    private PaymentResult payCourses(
+            Long userId,
+            List<PaymentCourse> courses,
+            PaymentSource source
+    ) {
+        if (courses == null || courses.isEmpty()) {
+            throw new BusinessException(
+                    ErrorCode.PAYMENT_EMPTY_COURSE);
+        }
+
+        long totalAmount = courses.stream().mapToLong(PaymentCourse::price).sum();
+
+        Order order = orderRepository.save(Order.paid(createOrderNo(), totalAmount, userId) );
+
+        List<OrderItem> orderItems = courses.stream().map(course -> orderItemRepository.save(
+                OrderItem.createCourse(course.title(), course.price(), order.getId(), course.courseId()))).toList();
+
+        Payment payment = paymentRepository.save(Payment.paid(totalAmount, order.getId(), userId));
+
+        long creditBalance = completeCoursePayment(userId, payment, orderItems, source);
+
+        PaymentPurchaseType purchaseType =
+                source == PaymentSource.CART
+                        ? PaymentPurchaseType.CART
+                        : PaymentPurchaseType.COURSE;
+
+        log.info("강의 결제 완료 - userId={}, orderId={}, paymentId={}, amount={}, courseCount={}",
+                userId,
+                order.getId(),
+                payment.getId(),
+                payment.getAmount(),
+                orderItems.size()
+        );
+
+        return new PaymentResult(order.getId(), order.getOrderNo(), payment.getId(), purchaseType, payment.getAmount(), payment.getStatus().name(), creditBalance, orderItems.stream()
+                        .map(item ->
+                                new PaidCourse(item.getCourseId(), item.getCourseTitle(), item.getFinalPrice())).toList(), null);
+    }
+
+    private long completeCoursePayment(
+            Long userId,
+            Payment payment,
+            List<OrderItem> orderItems,
+            PaymentSource source
+    ) {
+        CreditBalanceResult credit =
+                creditCommandUseCase.useCredit(
+                        new UseCreditCommand(
+                                userId,
+                                payment.getAmount()
+                        )
+                );
+
+        for (OrderItem orderItem : orderItems) {
+            enrollmentPort.enrollPaidCourse(
+                    userId,
+                    orderItem.getCourseId(),
+                    orderItem.getId()
+            );
+        }
+
+        if (source == PaymentSource.CART) {
+            cartItemRepository
+                    .deleteAllSelectedByUserId(userId);
+        }
+
+        return credit.balance();
+    }
+
+    private PaymentResult checkoutSubscription(Long userId, SubscriptionPlan plan) {
+        LocalDateTime now = LocalDateTime.now();
+
+        subscriptionRepository.findActiveByUserIdForUpdate(userId)
+                .ifPresent(subscription -> {
+                    if (subscription.isActive(now)) {
+                        throw new BusinessException(
+                                ErrorCode.SUBSCRIPTION_ALREADY_ACTIVE
+                        );
+                    }
+
+                    subscriptionRepository.save(
+                            subscription.expire()
+                    );
+                });
+
+        Order order = orderRepository.save(Order.paid(createOrderNo(), plan.getPrice(), userId));
+
+        Subscription subscription = subscriptionRepository.save(Subscription.start(userId, plan, now));
+
+        orderItemRepository.save(
+                OrderItem.createSubscription(plan.getPlanName(), plan.getPrice(), order.getId(), subscription.getId())
+        );
+
+        Payment payment = paymentRepository.save(
+                Payment.paid(plan.getPrice(), order.getId(),userId)
+        );
+
+        CreditBalanceResult credit =
+                creditCommandUseCase.useCredit(new UseCreditCommand(userId, payment.getAmount())
+                );
+
+        subscriptionPaymentRepository.save(
+                SubscriptionPayment.initial(
+                        subscription.getId(),
+                        order.getId(),
+                        payment.getId(),
+                        userId,
+                        order.getOrderNo(),
+                        plan,
+                        payment.getAmount(),
+                        payment.getPaidAt()
+                )
+        );
+
+        log.info(
+                "AI 구독권 결제 완료 - userId={}, subscriptionId={}, orderId={}, paymentId={}, plan={}, amount={}",
+                userId,
+                subscription.getId(),
+                order.getId(),
+                payment.getId(),
+                plan.name(),
+                payment.getAmount()
+        );
+
+        return new PaymentResult(
+                order.getId(),
+                order.getOrderNo(),
+                payment.getId(),
+                PaymentPurchaseType.AI_SUBSCRIPTION,
+                payment.getAmount(),
+                payment.getStatus().name(),
+                credit.balance(),
+                List.of(),
+                new PaidSubscription(
+                        subscription.getId(),
+                        plan.name(),
+                        plan.getPlanName(),
+                        subscription.getStatus().name(),
+                        subscription.getStartedAt(),
+                        subscription.getExpiredAt(),
+                        subscription.getNextBillingAt()
+                )
+        );
+    }
+
+    private String createOrderNo() {
+        return "ORD-" + LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyyMMddHHmmssSSS"))
+                + "-"
+                + UUID.randomUUID()
+                .toString()
+                .substring(0, 8)
+                .toUpperCase();
+    }
+
+    private enum PaymentSource {CART, DIRECT}
+
+    private record PaymentCourse(Long courseId, String title, Long price) {
+    }
+}

--- a/src/main/java/com/sashimi/payment/application/service/PaymentCommandService.java
+++ b/src/main/java/com/sashimi/payment/application/service/PaymentCommandService.java
@@ -1,356 +1,120 @@
 package com.sashimi.payment.application.service;
 
-import com.sashimi.cart.application.port.CourseInfo;
-import com.sashimi.cart.domain.model.CartItem;
-import com.sashimi.cart.domain.repository.CartItemRepository;
-import com.sashimi.credit.application.command.UseCreditCommand;
-import com.sashimi.credit.application.result.CreditBalanceResult;
-import com.sashimi.credit.application.usecase.CreditCommandUseCase;
-import com.sashimi.enrollment.application.port.EnrollmentPort;
 import com.sashimi.global.exception.BusinessException;
 import com.sashimi.global.exception.ErrorCode;
-import com.sashimi.order.application.policy.CoursePurchasePolicy;
-import com.sashimi.order.domain.model.Order;
-import com.sashimi.order.domain.model.OrderItem;
-import com.sashimi.order.domain.repository.OrderItemRepository;
-import com.sashimi.order.domain.repository.OrderRepository;
 import com.sashimi.payment.application.command.PaymentCheckoutCommand;
-import com.sashimi.payment.application.command.PaymentPurchaseType;
+import com.sashimi.payment.application.service
+        .PaymentIdempotencyTransactionService
+        .ExistingRequestResolution;
 import com.sashimi.payment.application.usecase.PaymentCommandUseCase;
-import com.sashimi.payment.domain.model.Payment;
-import com.sashimi.payment.domain.repository.PaymentRepository;
-import com.sashimi.subscription.domain.model.Subscription;
-import com.sashimi.subscription.domain.model.SubscriptionPayment;
-import com.sashimi.subscription.domain.model.SubscriptionPlan;
-import com.sashimi.subscription.domain.repository.SubscriptionPaymentRepository;
-import com.sashimi.subscription.domain.repository.SubscriptionRepository;
-import lombok.extern.slf4j.Slf4j;
+import com.sashimi.payment.domain.model.PaymentIdempotency;
+import lombok.RequiredArgsConstructor;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
-import java.time.LocalDateTime;
-import java.time.format.DateTimeFormatter;
-import java.util.List;
-import java.util.UUID;
-
-@Slf4j
 @Service
-@Transactional
+@RequiredArgsConstructor
 public class PaymentCommandService
         implements PaymentCommandUseCase {
 
-    private final CartItemRepository cartItemRepository;
-    private final CoursePurchasePolicy coursePurchasePolicy;
-    private final EnrollmentPort enrollmentPort;
-    private final OrderRepository orderRepository;
-    private final OrderItemRepository orderItemRepository;
-    private final PaymentRepository paymentRepository;
-    private final CreditCommandUseCase creditCommandUseCase;
-    private final SubscriptionRepository subscriptionRepository;
-    private final SubscriptionPaymentRepository
-            subscriptionPaymentRepository;
+    private final PaymentIdempotencyTransactionService
+            idempotencyTransactionService;
 
-    public PaymentCommandService(
-            CartItemRepository cartItemRepository,
-            CoursePurchasePolicy coursePurchasePolicy,
-            EnrollmentPort enrollmentPort,
-            OrderRepository orderRepository,
-            OrderItemRepository orderItemRepository,
-            PaymentRepository paymentRepository,
-            CreditCommandUseCase creditCommandUseCase,
-            SubscriptionRepository subscriptionRepository,
-            SubscriptionPaymentRepository
-                    subscriptionPaymentRepository
-    ) {
-        this.cartItemRepository = cartItemRepository;
-        this.coursePurchasePolicy = coursePurchasePolicy;
-        this.enrollmentPort = enrollmentPort;
-        this.orderRepository = orderRepository;
-        this.orderItemRepository = orderItemRepository;
-        this.paymentRepository = paymentRepository;
-        this.creditCommandUseCase = creditCommandUseCase;
-        this.subscriptionRepository = subscriptionRepository;
-        this.subscriptionPaymentRepository =
-                subscriptionPaymentRepository;
-    }
+    private final PaymentCheckoutTransactionService
+            checkoutTransactionService;
+
+    private final PaymentResultJsonCodec paymentResultJsonCodec;
 
     @Override
     public PaymentResult checkout(
             PaymentCheckoutCommand command
     ) {
-        if (!Boolean.TRUE.equals(command.agreed())) {
-            throw new BusinessException(
-                    ErrorCode.PAYMENT_AGREEMENT_REQUIRED);
-        }
+        validateIdempotencyKey(command.idempotencyKey());
 
-        if (command.purchaseType() == null) {
-            throw new BusinessException(
-                    ErrorCode.PAYMENT_INVALID_CHECKOUT_REQUEST);
-        }
+        String fingerprint = createFingerprint(command);
 
-        return switch (command.purchaseType()) {
-            case COURSE -> {
-                validateCourseRequest(command);
+        Long idempotencyId;
 
-                yield checkoutCourse(
-                        command.userId(),
-                        command.courseId());
-            }
+        try {
+            PaymentIdempotency created =
+                    idempotencyTransactionService.createProcessing(
+                            command.userId(),
+                            command.idempotencyKey(),
+                            fingerprint
+                    );
 
-            case CART -> {
-                validateCartRequest(command);
+            idempotencyId = created.getId();
+        } catch (DataIntegrityViolationException e) {
+            ExistingRequestResolution resolution =
+                    idempotencyTransactionService.resolveExisting(
+                            command.userId(),
+                            command.idempotencyKey(),
+                            fingerprint
+                    );
 
-                yield checkoutCart(command.userId());
-            }
+            switch (resolution.status()) {
+                case COMPLETED -> {
+                    return paymentResultJsonCodec.deserialize(
+                            resolution.resultJson()
+                    );
+                }
 
-            case AI_SUBSCRIPTION -> {
-                validateSubscriptionRequest(command);
-
-                yield checkoutSubscription(
-                        command.userId(),
-                        command.planCode());
-            }
-        };
-    }
-
-    private void validateCourseRequest(
-            PaymentCheckoutCommand command
-    ) {
-        if (command.courseId() == null
-                || command.courseId() <= 0) {
-            throw new BusinessException(
-                    ErrorCode.PAYMENT_COURSE_ID_REQUIRED);
-        }
-
-        if (command.planCode() != null) {
-            throw new BusinessException(
-                    ErrorCode.PAYMENT_PLAN_NOT_ALLOWED);
-        }
-    }
-
-    private void validateCartRequest(
-            PaymentCheckoutCommand command
-    ) {
-        if (command.courseId() != null) {
-            throw new BusinessException(
-                    ErrorCode.PAYMENT_CART_COURSE_ID_NOT_ALLOWED);
-        }
-
-        if (command.planCode() != null) {
-            throw new BusinessException(
-                    ErrorCode.PAYMENT_PLAN_NOT_ALLOWED);
-        }
-    }
-
-    private void validateSubscriptionRequest(
-            PaymentCheckoutCommand command
-    ) {
-        if (command.courseId() != null) {
-            throw new BusinessException(
-                    ErrorCode
-                            .PAYMENT_SUBSCRIPTION_COURSE_ID_NOT_ALLOWED);
-        }
-
-        if (command.planCode() == null) {
-            throw new BusinessException(
-                    ErrorCode.PAYMENT_SUBSCRIPTION_PLAN_REQUIRED);
-        }
-    }
-
-    private PaymentResult checkoutCourse(Long userId, Long courseId) {
-        CourseInfo course =
-                coursePurchasePolicy.validatePurchasable(
-                        userId,
-                        courseId);
-
-        PaymentResult result = payCourses(
-                userId,
-                List.of(
-                        new PaymentCourse(
-                                course.courseId(),
-                                course.title(),
-                                course.price())
-                ),
-                PaymentSource.DIRECT);
-
-        cartItemRepository.deleteByUserIdAndCourseId(userId, courseId);
-
-        return result;
-    }
-
-    private PaymentResult checkoutCart(Long userId) {
-        List<CartItem> cartItems =
-                cartItemRepository.findAllSelectedByUserId(
-                        userId);
-
-        if (cartItems.isEmpty()) {
-            throw new BusinessException(
-                    ErrorCode.CART_EMPTY_SELECTION);
-        }
-
-        List<PaymentCourse> courses = cartItems.stream().map(item -> coursePurchasePolicy.validatePurchasable(
-                userId, item.getCourseId()))
-                .map(course -> new PaymentCourse(course.courseId(), course.title(), course.price()))
-                .toList();
-        return payCourses(userId, courses, PaymentSource.CART);
-    }
-
-    private PaymentResult payCourses(
-            Long userId,
-            List<PaymentCourse> courses,
-            PaymentSource source
-    ) {
-        if (courses == null || courses.isEmpty()) {
-            throw new BusinessException(
-                    ErrorCode.PAYMENT_EMPTY_COURSE);
-        }
-
-        long totalAmount = courses.stream().mapToLong(PaymentCourse::price).sum();
-
-        Order order = orderRepository.save(Order.paid(createOrderNo(), totalAmount, userId) );
-
-        List<OrderItem> orderItems = courses.stream().map(course -> orderItemRepository.save(
-                OrderItem.createCourse(course.title(), course.price(), order.getId(), course.courseId()))).toList();
-
-        Payment payment = paymentRepository.save(Payment.paid(totalAmount, order.getId(), userId));
-
-        long creditBalance = completeCoursePayment(userId, payment, orderItems, source);
-
-        PaymentPurchaseType purchaseType =
-                source == PaymentSource.CART
-                        ? PaymentPurchaseType.CART
-                        : PaymentPurchaseType.COURSE;
-
-        log.info("강의 결제 완료 - userId={}, orderId={}, paymentId={}, amount={}, courseCount={}",
-                userId,
-                order.getId(),
-                payment.getId(),
-                payment.getAmount(),
-                orderItems.size()
-        );
-
-        return new PaymentResult(order.getId(), order.getOrderNo(), payment.getId(), purchaseType, payment.getAmount(), payment.getStatus().name(), creditBalance, orderItems.stream()
-                        .map(item ->
-                                new PaidCourse(item.getCourseId(), item.getCourseTitle(), item.getFinalPrice())).toList(), null);
-    }
-
-    private long completeCoursePayment(
-            Long userId,
-            Payment payment,
-            List<OrderItem> orderItems,
-            PaymentSource source
-    ) {
-        CreditBalanceResult credit =
-                creditCommandUseCase.useCredit(
-                        new UseCreditCommand(
-                                userId,
-                                payment.getAmount()
-                        )
+                case PROCESSING -> throw new BusinessException(
+                        ErrorCode.PAYMENT_IDEMPOTENCY_PROCESSING
                 );
 
-        for (OrderItem orderItem : orderItems) {
-            enrollmentPort.enrollPaidCourse(
-                    userId,
-                    orderItem.getCourseId(),
-                    orderItem.getId()
+                case FAILED -> throw new BusinessException(
+                        ErrorCode.PAYMENT_IDEMPOTENCY_FAILED
+                );
+
+                case RESTARTED ->
+                        idempotencyId =
+                                resolution.idempotencyId();
+
+                default -> throw new BusinessException(
+                        ErrorCode
+                                .PAYMENT_IDEMPOTENCY_RESULT_INVALID
+                );
+            }
+        }
+
+        try {
+            return checkoutTransactionService.execute(
+                    command,
+                    idempotencyId
+            );
+        } catch (RuntimeException e) {
+            idempotencyTransactionService.markFailed(
+                    idempotencyId
+            );
+
+            throw e;
+        }
+    }
+
+    private void validateIdempotencyKey(String key) {
+        if (key == null
+                || key.isBlank()
+                || key.length() > 100) {
+            throw new BusinessException(
+                    ErrorCode.PAYMENT_IDEMPOTENCY_KEY_INVALID
             );
         }
-
-        if (source == PaymentSource.CART) {
-            cartItemRepository
-                    .deleteAllSelectedByUserId(userId);
-        }
-
-        return credit.balance();
     }
 
-    private PaymentResult checkoutSubscription(Long userId, SubscriptionPlan plan) {
-        LocalDateTime now = LocalDateTime.now();
-
-        subscriptionRepository.findActiveByUserIdForUpdate(userId)
-                .ifPresent(subscription -> {
-                    if (subscription.isActive(now)) {
-                        throw new BusinessException(
-                                ErrorCode.SUBSCRIPTION_ALREADY_ACTIVE
-                        );
-                    }
-
-                    subscriptionRepository.save(
-                            subscription.expire()
-                    );
-                });
-
-        Order order = orderRepository.save(Order.paid(createOrderNo(), plan.getPrice(), userId));
-
-        Subscription subscription = subscriptionRepository.save(Subscription.start(userId, plan, now));
-
-        orderItemRepository.save(
-                OrderItem.createSubscription(plan.getPlanName(), plan.getPrice(), order.getId(), subscription.getId())
-        );
-
-        Payment payment = paymentRepository.save(
-                Payment.paid(plan.getPrice(), order.getId(),userId)
-        );
-
-        CreditBalanceResult credit =
-                creditCommandUseCase.useCredit(new UseCreditCommand(userId, payment.getAmount())
-                );
-
-        subscriptionPaymentRepository.save(
-                SubscriptionPayment.initial(
-                        subscription.getId(),
-                        order.getId(),
-                        payment.getId(),
-                        userId,
-                        order.getOrderNo(),
-                        plan,
-                        payment.getAmount(),
-                        payment.getPaidAt()
-                )
-        );
-
-        log.info(
-                "AI 구독권 결제 완료 - userId={}, subscriptionId={}, orderId={}, paymentId={}, plan={}, amount={}",
-                userId,
-                subscription.getId(),
-                order.getId(),
-                payment.getId(),
-                plan.name(),
-                payment.getAmount()
-        );
-
-        return new PaymentResult(
-                order.getId(),
-                order.getOrderNo(),
-                payment.getId(),
-                PaymentPurchaseType.AI_SUBSCRIPTION,
-                payment.getAmount(),
-                payment.getStatus().name(),
-                credit.balance(),
-                List.of(),
-                new PaidSubscription(
-                        subscription.getId(),
-                        plan.name(),
-                        plan.getPlanName(),
-                        subscription.getStatus().name(),
-                        subscription.getStartedAt(),
-                        subscription.getExpiredAt(),
-                        subscription.getNextBillingAt()
-                )
-        );
+    private String createFingerprint(
+            PaymentCheckoutCommand command
+    ) {
+        return command.purchaseType()
+                + ":"
+                + valueOf(command.courseId())
+                + ":"
+                + valueOf(command.planCode());
     }
 
-    private String createOrderNo() {
-        return "ORD-" + LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyyMMddHHmmssSSS"))
-                + "-"
-                + UUID.randomUUID()
-                .toString()
-                .substring(0, 8)
-                .toUpperCase();
-    }
-
-    private enum PaymentSource {CART, DIRECT}
-
-    private record PaymentCourse(Long courseId, String title, Long price) {
+    private String valueOf(Object value) {
+        return value == null
+                ? "-"
+                : value.toString();
     }
 }

--- a/src/main/java/com/sashimi/payment/application/service/PaymentIdempotencyTransactionService.java
+++ b/src/main/java/com/sashimi/payment/application/service/PaymentIdempotencyTransactionService.java
@@ -1,0 +1,146 @@
+package com.sashimi.payment.application.service;
+
+import com.sashimi.global.exception.BusinessException;
+import com.sashimi.global.exception.ErrorCode;
+import com.sashimi.payment.domain.model.PaymentIdempotency;
+import com.sashimi.payment.domain.repository.PaymentIdempotencyRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+
+@Service
+@RequiredArgsConstructor
+public class PaymentIdempotencyTransactionService {
+
+    private static final long PROCESSING_TIMEOUT_MINUTES = 5L;
+
+    private final PaymentIdempotencyRepository repository;
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public PaymentIdempotency createProcessing(
+            Long userId,
+            String key,
+            String fingerprint
+    ) {
+        return repository.saveAndFlush(
+                PaymentIdempotency.processing(
+                        userId,
+                        key,
+                        fingerprint
+                )
+        );
+    }
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public ExistingRequestResolution resolveExisting(
+            Long userId,
+            String key,
+            String fingerprint
+    ) {
+        PaymentIdempotency existing =
+                repository
+                        .findByUserIdAndIdempotencyKeyForUpdate(
+                                userId,
+                                key
+                        )
+                        .orElseThrow(() -> new BusinessException(
+                                ErrorCode
+                                        .PAYMENT_IDEMPOTENCY_RESULT_INVALID
+                        ));
+
+        existing.validateFingerprint(fingerprint);
+
+        if (existing.isCompleted()) {
+            return ExistingRequestResolution.completed(
+                    existing.getResultJson()
+            );
+        }
+
+        if (existing.isFailed()) {
+            return ExistingRequestResolution.failed();
+        }
+
+        LocalDateTime now = LocalDateTime.now();
+
+        if (existing.isProcessingExpired(
+                now,
+                PROCESSING_TIMEOUT_MINUTES
+        )) {
+            existing.restartProcessing();
+
+            PaymentIdempotency saved =
+                    repository.save(existing);
+
+            return ExistingRequestResolution.restarted(
+                    saved.getId()
+            );
+        }
+
+        return ExistingRequestResolution.processing();
+    }
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void markFailed(Long id) {
+        PaymentIdempotency idempotency =
+                repository.findByIdForUpdate(id)
+                        .orElseThrow(() -> new BusinessException(
+                                ErrorCode
+                                        .PAYMENT_IDEMPOTENCY_RESULT_INVALID
+                        ));
+
+        idempotency.fail();
+        repository.save(idempotency);
+    }
+
+    public enum ExistingRequestStatus {
+        COMPLETED,
+        PROCESSING,
+        RESTARTED,
+        FAILED
+    }
+
+    public record ExistingRequestResolution(
+            ExistingRequestStatus status,
+            Long idempotencyId,
+            String resultJson
+    ) {
+        public static ExistingRequestResolution completed(
+                String resultJson
+        ) {
+            return new ExistingRequestResolution(
+                    ExistingRequestStatus.COMPLETED,
+                    null,
+                    resultJson
+            );
+        }
+
+        public static ExistingRequestResolution processing() {
+            return new ExistingRequestResolution(
+                    ExistingRequestStatus.PROCESSING,
+                    null,
+                    null
+            );
+        }
+
+        public static ExistingRequestResolution restarted(
+                Long idempotencyId
+        ) {
+            return new ExistingRequestResolution(
+                    ExistingRequestStatus.RESTARTED,
+                    idempotencyId,
+                    null
+            );
+        }
+
+        public static ExistingRequestResolution failed() {
+            return new ExistingRequestResolution(
+                    ExistingRequestStatus.FAILED,
+                    null,
+                    null
+            );
+        }
+    }
+}

--- a/src/main/java/com/sashimi/payment/application/service/PaymentResultJsonCodec.java
+++ b/src/main/java/com/sashimi/payment/application/service/PaymentResultJsonCodec.java
@@ -1,0 +1,39 @@
+package com.sashimi.payment.application.service;
+
+import com.sashimi.global.exception.BusinessException;
+import com.sashimi.global.exception.ErrorCode;
+import com.sashimi.payment.application.usecase.PaymentCommandUseCase.PaymentResult;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import tools.jackson.core.JacksonException;
+import tools.jackson.databind.ObjectMapper;
+
+@Component
+@RequiredArgsConstructor
+public class PaymentResultJsonCodec {
+
+    private final ObjectMapper objectMapper;
+
+    public String serialize(PaymentResult result) {
+        try {
+            return objectMapper.writeValueAsString(result);
+        } catch (JacksonException e) {
+            throw new BusinessException(
+                    ErrorCode.PAYMENT_IDEMPOTENCY_RESULT_INVALID
+            );
+        }
+    }
+
+    public PaymentResult deserialize(String resultJson) {
+        try {
+            return objectMapper.readValue(
+                    resultJson,
+                    PaymentResult.class
+            );
+        } catch (JacksonException e) {
+            throw new BusinessException(
+                    ErrorCode.PAYMENT_IDEMPOTENCY_RESULT_INVALID
+            );
+        }
+    }
+}

--- a/src/main/java/com/sashimi/payment/domain/model/PaymentIdempotency.java
+++ b/src/main/java/com/sashimi/payment/domain/model/PaymentIdempotency.java
@@ -1,0 +1,119 @@
+package com.sashimi.payment.domain.model;
+
+import com.sashimi.global.exception.BusinessException;
+import com.sashimi.global.exception.ErrorCode;
+import java.time.LocalDateTime;
+import java.util.Objects;
+
+public class PaymentIdempotency {
+
+    private final Long id;
+    private final Long userId;
+    private final String idempotencyKey;
+    private final String requestFingerprint;
+    private PaymentIdempotencyStatus status;
+    private String resultJson;
+    private final LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+
+    private PaymentIdempotency(
+            Long id, Long userId, String idempotencyKey,
+            String requestFingerprint, PaymentIdempotencyStatus status,
+            String resultJson, LocalDateTime createdAt, LocalDateTime updatedAt
+    ) {
+        if (userId == null || idempotencyKey == null || idempotencyKey.isBlank()
+                || requestFingerprint == null || requestFingerprint.isBlank()
+                || status == null) {
+            throw new BusinessException(ErrorCode.INVALID_INPUT_VALUE);
+        }
+
+        this.id = id;
+        this.userId = userId;
+        this.idempotencyKey = idempotencyKey;
+        this.requestFingerprint = requestFingerprint;
+        this.status = status;
+        this.resultJson = resultJson;
+        this.createdAt = createdAt == null ? LocalDateTime.now() : createdAt;
+        this.updatedAt = updatedAt == null ? LocalDateTime.now() : updatedAt;
+    }
+
+    public static PaymentIdempotency processing(
+            Long userId, String key, String fingerprint
+    ) {
+        LocalDateTime now = LocalDateTime.now();
+        return new PaymentIdempotency(
+                null, userId, key, fingerprint,
+                PaymentIdempotencyStatus.PROCESSING, null, now, now
+        );
+    }
+
+    public static PaymentIdempotency restore(
+            Long id, Long userId, String key, String fingerprint,
+            PaymentIdempotencyStatus status, String resultJson,
+            LocalDateTime createdAt, LocalDateTime updatedAt
+    ) {
+        return new PaymentIdempotency(
+                id, userId, key, fingerprint, status,
+                resultJson, createdAt, updatedAt
+        );
+    }
+
+    public void validateFingerprint(String fingerprint) {
+        if (!Objects.equals(requestFingerprint, fingerprint)) {
+            throw new BusinessException(
+                    ErrorCode.PAYMENT_IDEMPOTENCY_KEY_CONFLICT);
+        }
+    }
+
+    public void restartProcessing() {
+        if (status != PaymentIdempotencyStatus.PROCESSING) {
+            throw new BusinessException(
+                    ErrorCode.PAYMENT_IDEMPOTENCY_RESULT_INVALID
+            );
+        }
+
+        resultJson = null;
+        updatedAt = LocalDateTime.now();
+    }
+
+    public void complete(String resultJson) {
+        if (status != PaymentIdempotencyStatus.PROCESSING
+                || resultJson == null || resultJson.isBlank()) {
+            throw new BusinessException(
+                    ErrorCode.PAYMENT_IDEMPOTENCY_RESULT_INVALID);
+        }
+
+        status = PaymentIdempotencyStatus.COMPLETED;
+        this.resultJson = resultJson;
+        updatedAt = LocalDateTime.now();
+    }
+
+    public void fail() {
+        if (status == PaymentIdempotencyStatus.PROCESSING) {
+            status = PaymentIdempotencyStatus.FAILED;
+            updatedAt = LocalDateTime.now();
+        }
+    }
+
+    public boolean isProcessingExpired(LocalDateTime now, long timeoutMinutes) {
+        if (!isProcessing()) {return false;
+        }
+
+        return updatedAt.isBefore(
+                now.minusMinutes(timeoutMinutes)
+        );
+    }
+
+    public boolean isProcessing() { return status == PaymentIdempotencyStatus.PROCESSING; }
+    public boolean isCompleted() { return status == PaymentIdempotencyStatus.COMPLETED; }
+    public boolean isFailed() { return status == PaymentIdempotencyStatus.FAILED; }
+
+    public Long getId() { return id; }
+    public Long getUserId() { return userId; }
+    public String getIdempotencyKey() { return idempotencyKey; }
+    public String getRequestFingerprint() { return requestFingerprint; }
+    public PaymentIdempotencyStatus getStatus() { return status; }
+    public String getResultJson() { return resultJson; }
+    public LocalDateTime getCreatedAt() { return createdAt; }
+    public LocalDateTime getUpdatedAt() { return updatedAt; }
+}

--- a/src/main/java/com/sashimi/payment/domain/model/PaymentIdempotencyStatus.java
+++ b/src/main/java/com/sashimi/payment/domain/model/PaymentIdempotencyStatus.java
@@ -1,0 +1,7 @@
+package com.sashimi.payment.domain.model;
+
+public enum PaymentIdempotencyStatus {
+    PROCESSING,
+    COMPLETED,
+    FAILED
+}

--- a/src/main/java/com/sashimi/payment/domain/repository/PaymentIdempotencyRepository.java
+++ b/src/main/java/com/sashimi/payment/domain/repository/PaymentIdempotencyRepository.java
@@ -1,0 +1,16 @@
+package com.sashimi.payment.domain.repository;
+
+import com.sashimi.payment.domain.model.PaymentIdempotency;
+
+import java.util.Optional;
+
+public interface PaymentIdempotencyRepository {
+
+    PaymentIdempotency save(PaymentIdempotency idempotency);
+
+    PaymentIdempotency saveAndFlush(PaymentIdempotency idempotency);
+
+    Optional<PaymentIdempotency> findByUserIdAndIdempotencyKeyForUpdate(Long userId, String idempotencyKey);
+
+    Optional<PaymentIdempotency> findByIdForUpdate(Long id);
+}

--- a/src/main/java/com/sashimi/payment/infrastructure/persistence/PaymentIdempotencyJpaEntity.java
+++ b/src/main/java/com/sashimi/payment/infrastructure/persistence/PaymentIdempotencyJpaEntity.java
@@ -1,0 +1,82 @@
+package com.sashimi.payment.infrastructure.persistence;
+
+import com.sashimi.payment.domain.model.PaymentIdempotency;
+import com.sashimi.payment.domain.model.PaymentIdempotencyStatus;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(
+        name = "payment_idempotencies",
+        uniqueConstraints = @UniqueConstraint(
+                name = "uq_payment_idempotencies_user_key",
+                columnNames = {"user_id", "idempotency_key"}
+        )
+)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class PaymentIdempotencyJpaEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "payment_idempotency_id")
+    private Long id;
+
+    @Column(name = "user_id", nullable = false)
+    private Long userId;
+
+    @Column(name = "idempotency_key", nullable = false, length = 100)
+    private String idempotencyKey;
+
+    @Column(name = "request_fingerprint", nullable = false, length = 200)
+    private String requestFingerprint;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", nullable = false, length = 20)
+    private PaymentIdempotencyStatus status;
+
+    @Lob
+    @Column(name = "result_json")
+    private String resultJson;
+
+    @Column(name = "created_at", nullable = false)
+    private LocalDateTime createdAt;
+
+    @Column(name = "updated_at", nullable = false)
+    private LocalDateTime updatedAt;
+
+    public static PaymentIdempotencyJpaEntity from(
+            PaymentIdempotency idempotency
+    ) {
+        PaymentIdempotencyJpaEntity entity =
+                new PaymentIdempotencyJpaEntity();
+
+        entity.id = idempotency.getId();
+        entity.userId = idempotency.getUserId();
+        entity.idempotencyKey =
+                idempotency.getIdempotencyKey();
+        entity.requestFingerprint =
+                idempotency.getRequestFingerprint();
+        entity.status = idempotency.getStatus();
+        entity.resultJson = idempotency.getResultJson();
+        entity.createdAt = idempotency.getCreatedAt();
+        entity.updatedAt = idempotency.getUpdatedAt();
+
+        return entity;
+    }
+
+    public PaymentIdempotency toDomain() {
+        return PaymentIdempotency.restore(
+                id,
+                userId,
+                idempotencyKey,
+                requestFingerprint,
+                status,
+                resultJson,
+                createdAt,
+                updatedAt
+        );
+    }
+}

--- a/src/main/java/com/sashimi/payment/infrastructure/persistence/PaymentIdempotencyRepositoryAdapter.java
+++ b/src/main/java/com/sashimi/payment/infrastructure/persistence/PaymentIdempotencyRepositoryAdapter.java
@@ -1,0 +1,57 @@
+package com.sashimi.payment.infrastructure.persistence;
+
+import com.sashimi.payment.domain.model.PaymentIdempotency;
+import com.sashimi.payment.domain.repository.PaymentIdempotencyRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+@RequiredArgsConstructor
+public class PaymentIdempotencyRepositoryAdapter
+        implements PaymentIdempotencyRepository {
+
+    private final SpringDataPaymentIdempotencyRepository repository;
+
+    @Override
+    public PaymentIdempotency save(
+            PaymentIdempotency idempotency
+    ) {
+        return repository.save(
+                PaymentIdempotencyJpaEntity.from(idempotency)
+        ).toDomain();
+    }
+
+    @Override
+    public PaymentIdempotency saveAndFlush(
+            PaymentIdempotency idempotency
+    ) {
+        return repository.saveAndFlush(
+                PaymentIdempotencyJpaEntity.from(idempotency)
+        ).toDomain();
+    }
+
+
+    @Override
+    public Optional<PaymentIdempotency> findByIdForUpdate(
+            Long id
+    ) {
+        return repository.findByIdForUpdate(id)
+                .map(PaymentIdempotencyJpaEntity::toDomain);
+    }
+
+    @Override
+    public Optional<PaymentIdempotency>
+    findByUserIdAndIdempotencyKeyForUpdate(
+            Long userId,
+            String idempotencyKey
+    ) {
+        return repository
+                .findByUserIdAndIdempotencyKeyForUpdate(
+                        userId,
+                        idempotencyKey
+                )
+                .map(PaymentIdempotencyJpaEntity::toDomain);
+    }
+}

--- a/src/main/java/com/sashimi/payment/infrastructure/persistence/SpringDataPaymentIdempotencyRepository.java
+++ b/src/main/java/com/sashimi/payment/infrastructure/persistence/SpringDataPaymentIdempotencyRepository.java
@@ -1,0 +1,36 @@
+package com.sashimi.payment.infrastructure.persistence;
+
+import jakarta.persistence.LockModeType;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.Optional;
+
+public interface SpringDataPaymentIdempotencyRepository
+        extends JpaRepository<PaymentIdempotencyJpaEntity, Long> {
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("""
+            select p
+            from PaymentIdempotencyJpaEntity p
+            where p.id = :id
+            """)
+    Optional<PaymentIdempotencyJpaEntity> findByIdForUpdate(
+            @Param("id") Long id
+    );
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("""
+        select p
+        from PaymentIdempotencyJpaEntity p
+        where p.userId = :userId
+          and p.idempotencyKey = :idempotencyKey
+        """)
+    Optional<PaymentIdempotencyJpaEntity>
+    findByUserIdAndIdempotencyKeyForUpdate(
+            @Param("userId") Long userId,
+            @Param("idempotencyKey") String idempotencyKey
+    );
+}

--- a/src/main/java/com/sashimi/payment/presentation/api/PaymentController.java
+++ b/src/main/java/com/sashimi/payment/presentation/api/PaymentController.java
@@ -10,6 +10,7 @@ import com.sashimi.payment.presentation.api.response.PaymentPreviewResponse;
 import com.sashimi.payment.presentation.api.response.PaymentResponse;
 import com.sashimi.security.principal.CustomUserPrincipal;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -158,6 +159,11 @@ public class PaymentController {
     @PostMapping("/checkout")
     public ResponseEntity<PaymentResponse> checkout(
             @AuthenticationPrincipal CustomUserPrincipal principal,
+            @Parameter(description = "중복 결제 방지를 위한 요청 식별 키",
+                    required = true,
+                    example = "550e8400-e29b-41d4-a716-446655440000")
+            @RequestHeader(value = "Idempotency-Key", required = false)
+            String idempotencyKey,
             @RequestBody @Valid PaymentCheckoutRequest request
     ) {
         PaymentCommandUseCase.PaymentResult result =
@@ -167,7 +173,8 @@ public class PaymentController {
                                 request.purchaseType(),
                                 request.courseId(),
                                 request.planCode(),
-                                request.agreed()
+                                request.agreed(),
+                                idempotencyKey
                         )
                 );
 

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -44,6 +44,8 @@ toss:
   payments:
     base-url: https://api.tosspayments.com
     secret-key: ${TOSS_PAYMENTS_SECRET_KEY:}
+    connect-timeout: 3s
+    read-timeout: 5s
 
 external:
   ncs:

--- a/src/main/resources/db/migration/be3/V3.3.1__create_payment_idempotencies.sql
+++ b/src/main/resources/db/migration/be3/V3.3.1__create_payment_idempotencies.sql
@@ -1,0 +1,23 @@
+CREATE TABLE payment_idempotencies (
+                                       payment_idempotency_id BIGINT NOT NULL AUTO_INCREMENT,
+                                       user_id BIGINT NOT NULL,
+                                       idempotency_key VARCHAR(100) NOT NULL,
+                                       request_fingerprint VARCHAR(200) NOT NULL,
+                                       status VARCHAR(20) NOT NULL,
+                                       result_json TEXT NULL,
+                                       created_at DATETIME(6) NOT NULL,
+                                       updated_at DATETIME(6) NOT NULL,
+
+                                       PRIMARY KEY (payment_idempotency_id),
+
+                                       CONSTRAINT uq_payment_idempotencies_user_key
+                                           UNIQUE (user_id, idempotency_key),
+
+                                       CONSTRAINT fk_payment_idempotencies_user
+                                           FOREIGN KEY (user_id)
+                                               REFERENCES users(user_id),
+
+                                       INDEX idx_payment_idempotencies_created_at (
+        created_at
+    )
+);

--- a/src/test/java/com/sashimi/payment/application/service/PaymentCommandServiceTest.java
+++ b/src/test/java/com/sashimi/payment/application/service/PaymentCommandServiceTest.java
@@ -67,7 +67,7 @@ class PaymentCommandServiceTest {
     private SubscriptionRepository subscriptionRepository;
     private SubscriptionPaymentRepository subscriptionPaymentRepository;
 
-    private PaymentCommandService paymentCommandService;
+    private PaymentCheckoutTransactionService paymentCommandService;
 
     @BeforeEach
     void setUp() {
@@ -98,7 +98,7 @@ class PaymentCommandServiceTest {
         subscriptionPaymentRepository =
                 mock(SubscriptionPaymentRepository.class);
 
-        paymentCommandService = new PaymentCommandService(
+        paymentCommandService = new PaymentCheckoutTransactionService(
                 cartItemRepository,
                 coursePurchasePolicy,
                 enrollmentPort,


### PR DESCRIPTION
## 📌 PR 요약
결제 및 크레딧 충전 과정의 운영 안정성을 강화
토스 결제 승인과 크레딧 반영의 트랜잭션 범위를 분리하여 외부 API 호출로 인한 DB 트랜잭션 장기 점유를 줄였으며, 결제 API에 멱등성 키를 적용해 중복 클릭이나 네트워크 재요청으로 발생할 수 있는 중복 주문 및 크레딧 이중 차감을 방지

---

## 🛠️ 작업 상세 내용 (체크로 선택)
- [ ] ✨ FEATURE
- [ ] 🔧 UPDATE
- [ ] 🐛 BUGFIX
- [ ] ♻️ REFACTOR
- [ ] 📝 DOCS

---

## 📋 작업 상세 내용
1. 토스 결제 승인 흐름 안정화
2. 내부 결제 멱등성 적용
3. 결제 서비스 구조 분리
4. 결제 결과 저장 및 복원
5. DB 변경
6. 예외 처리 추가

---

## 🔗 PR 관련 이슈로 닫기
Closes #293
Closes #294 

---

## ✅ 체크리스트 (확인 절차)
- [ ] 정상적으로 빌드 및 실행됩니다.
- [ ] 주요 기능이 정상 동작합니다.
- [ ] 불필요한 코드를 제거했습니다.
- [ ] 코드 리뷰 준비가 완료되었습니다.

---

## 💬 리뷰어에게 할 말
- 

---

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * 결제/충전 흐름에 멱등성 키 지원이 추가되어 중복 요청을 더 안전하게 처리합니다.
  * 결제 승인 실패 시 결제 조회로 자동 복구해 결제 성공률과 안정성이 향상되었습니다.
  * 크레딧 충전 완료 후 잔액과 결제 결과를 일관되게 반영합니다.
* **Bug Fixes**
  * 결제키, 주문 정보, 금액 불일치 시 더 명확하게 실패 처리합니다.
  * 이미 처리된 결제는 재요청 시 기존 결과를 반환하도록 개선되었습니다.
* **Chores**
  * 외부 결제 연동 설정에 타임아웃과 관련 응답 문서가 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->